### PR TITLE
Fix main module shimming for inferred extensions

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -1,0 +1,7 @@
+// Try running this as `node-dev main` instead of `node-dev main.js`:
+if (module !== require.main) {
+    console.error('Expected to be the main module; not the case.')
+    process.exit(1);
+} else {
+    process.exit(0);
+}

--- a/wrapper.js
+++ b/wrapper.js
@@ -8,6 +8,7 @@ var fs = require('fs')
   , vm = require('vm')
   , spawn = require('child_process').spawn
   , clearScreen = /true|yes|on|1/i.test(process.env.NODE_DEV_CLEARSCREEN)
+  , wrapper = module    // Save a reference to this module
 
 // Remove wrapper.js from the argv array
 process.argv.splice(1, 1)
@@ -110,7 +111,7 @@ var origs = {}
 
 function createHook(ext) {
   return function(module, filename) {
-    if (module.id == main) {
+    if (module.parent == wrapper) {
       // If the main module is required conceal the wrapper
       module.id = '.'
       module.parent = null


### PR DESCRIPTION
The native `node` binary, just like `require()`, allows specifying paths that aren't directly to the file; they can point to a folder or just the filename without the extension.

`node-dev` runs those files fine, but it just wasn't detecting the "main" module in those cases. Fixed by checking `module.parent` instead of using the passed-in path.

Added a simple test case; try e.g. `node-dev test/main`.
