### PR TITLE
Add livescript support and diable growl notifications

### DIFF
--- a/test/app.ls
+++ b/test/app.ls
@@ -1,0 +1,13 @@
+http = require \http
+message = require \./message
+
+server = http.createServer (req, res) ->
+    res.writeHead 200, \Content-Type: \text/plain
+
+    res.write message
+    res.end \\n
+
+server.listen 8080
+
+console.log 'Server running at http://localhost:8080/'
+console.log message

--- a/wrapper.js
+++ b/wrapper.js
@@ -35,7 +35,7 @@ function log(msg, level) {
 function notify(title, msg, level) {
   level = level || 'info'
   log(title || msg, level)
-  growl(msg, { title: title || 'node.js', image: __dirname + '/icons/node_' + level + '.png' })
+  growl(msg, { title: title || 'node.js', image: __dirname + '/icons/node_' + level + '.png', sticky: false })
 }
 
 /**
@@ -164,14 +164,18 @@ patch(vm, 'runInContext', 2)
 
 // Error handler that displays a notification and logs the stack to stderr:
 process.on('uncaughtException', function(err) {
- notify(err.name, err.message, 'error')
- console.error(err.stack || err)
+  notify(err.name, err.message, 'error')
+  console.error(err.stack || err)
 })
 
 process.on('exit', checkExitCode)
 
 if (Path.extname(main) == '.coffee') {
   require('coffee-script')
+}
+
+if (Path.extname(main) == '.ls') {
+  require('LiveScript')
 }
 
 require(main)


### PR DESCRIPTION
- add livescript support(use nearly the same code as the code for coffeescript)
- disable the notifications of growl.. not a good Idea, though.

The problem I came across is that there are always too many icons stay in GNOME3, and here's my screenshot.
I tested `growl({sticky: false})` before but didn't work as expetcted. So I'm trying to diable it.
But that's also a bad solution...

http://forum.ubuntu.org.cn/viewtopic.php?f=48&t=385998
![too many](http://forum.ubuntu.org.cn/download/file.php?id=162571&mode=view/last.png)
