### PR TITLE
Use process.env.USERPROFILE for Windows

### DIFF
--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -7,7 +7,7 @@ function read(dir) {
 }
 
 var c = read('.')
-c.__proto__ = read(process.env.HOME)
+c.__proto__ = read(process.env.HOME || process.env.USERPROFILE)
 
 module.exports = {
   vm         : c.vm !== false,


### PR DESCRIPTION
At present node-dev crashes due to process.env.HOME being undefined on Windows machines, which have a rough equivalent of process.env.USERPROFILE.
