### PR TITLE
revert to builtin fs.watch

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 var fork = require('child_process').fork
-  , FSWatcher = require('chokidar').FSWatcher
+  , fs = require('fs')
   , ipc = require('./ipc')
   , notify = require('./notify')
   , cfg = require('./cfg')
@@ -18,22 +18,25 @@ module.exports = function(args) {
     }
   }
 
-  var watcher = new FSWatcher({ persistent: true })
+  var watchers = {}
+  var start_time
 
-  watcher.on('change', function(file) {
-    if (cfg.clear) process.stdout.write('\033[2J\033[H')
-    notify('Restarting', file + ' has been modified')
-    watcher.close()
-    if (child) {
-      // Child is still running, restart upon exit
-      child.on('exit', start)
-      stop()
+  function mk_change(file) {
+    return function(ev) {
+
+      // avoids an issue seen on OSX where atime caused restarts
+      // but atime doesn't matter
+      var stat = fs.statSync(file)
+      if (start_time && stat.mtime && stat.mtime < start_time) {
+        return
+      }
+
+      if (cfg.clear) process.stdout.write('\033[2J\033[H')
+      notify('Restarting', file + ' has been modified')
+      watchers[file].close()
+      stop();
     }
-    else {
-      // Child is already stopped, probably due to a previous error
-      start()
-    }
-  })
+  }
 
   /**
    * Run the wrapped script.
@@ -46,11 +49,27 @@ module.exports = function(args) {
     .on('exit', function(code) {
       if (!child.respawn) process.exit(code)
       child = undefined
+
+      // close current watchers, newly launched program may have different files
+      Object.keys(watchers).forEach(function(filename) {
+        watchers[filename].close()
+      })
+      watchers = {}
+      setImmediate(start)
     })
+
+    start_time = new Date()
 
     // Listen for `required` messages and watch the required file.
     ipc.on(child, 'required', function(m) {
-      watcher.add(m.required)
+      var filename = m.required
+      // only watch once
+      if (filename in watchers) {
+        return
+      }
+
+      var watcher = fs.watch(filename, mk_change(filename))
+      watchers[filename] = watcher
     })
 
     // Upon errors, display a notification and tell the child to exit.

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   },
   "dependencies": {
     "growl": "~1.7.0",
-    "dateformat": "~1.0.4-1.2.3",
-    "chokidar": "~0.6.2"
+    "dateformat": "~1.0.4-1.2.3"
   },
   "devDependencies": {
     "mocha": "~1.4.1",


### PR DESCRIPTION
Better CPU usage on osx (maybe other systems as well)

The other module being used for fs events defaults to polling which causes high CPU usage for no reason. I have removed it in favor of the nodejs fs.watch system and a basic mtime check to avoid atime triggering. This has drastically reduced my cpu usage on OSX.
