### PR TITLE
Added Env Section to Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
 [![Build Status](https://secure.travis-ci.org/fgnass/node-dev.png)](http://travis-ci.org/fgnass/node-dev)
 
-# node-dev
+# node-dev-env
 
-Node-dev is a development tool for [Node.js](http://nodejs.org) that
+Node-dev-env is a development tool for [Node.js](http://nodejs.org) that
 automatically restarts the node process when a script is modified.
 
 It's an alternative to tools like
 [supervisor](https://github.com/isaacs/node-supervisor) or
 [nodemon](https://github.com/remy/nodemon) that doesn't require any
-configuration. Just run `node-dev foo.js` as you would normally run `node` and
+configuration. Just run `node-dev-env foo.js` as you would normally run `node` and
 it will automatically figure out which files need to be watched.
 
 You may also use node-dev with [CoffeeScript](http://http://coffeescript.org/)
-or [LiveScript](http://livescript.net/) apps. Just run `node-dev app.coffee`
-or `node-dev app.ls`. You may also register additional language flavors by
+or [LiveScript](http://livescript.net/) apps. Just run `node-dev-env app.coffee`
+or `node-dev-env app.ls`. You may also register additional language flavors by
 adding them to the extensions list in your [.node-dev.json](#settings) config
 file.
+
+__Note:__ this is a fork from fgnass/node-dev because I needed the ability to set env vars in the config file and could not wait for the changes to be merged
 
 ### Desktop Notifications
 
@@ -31,7 +33,7 @@ Status and error messages can be displayed as desktop notification using either
 
 Node-dev can be installed via [npm](http://github.com/isaacs/npm):
 
-    npm install -g node-dev
+    npm install -g node-dev-env
 
 In order to use Growl notifications
 [growlnotify](http://growl.info/extras.php#growlnotify) must be installed on

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ automatically restarts the node process when a script is modified.
 It's an alternative to tools like
 [supervisor](https://github.com/isaacs/node-supervisor) or
 [nodemon](https://github.com/remy/nodemon) that doesn't require any
-configuration. Just run `node-dev-env foo.js` as you would normally run `node` and
+configuration. Just run `node-dev foo.js` as you would normally run `node` and
 it will automatically figure out which files need to be watched.
 
 You may also use node-dev with [CoffeeScript](http://http://coffeescript.org/)
-or [LiveScript](http://livescript.net/) apps. Just run `node-dev-env app.coffee`
+or [LiveScript](http://livescript.net/) apps. Just run `node-dev app.coffee`
 or `node-dev-env app.ls`. You may also register additional language flavors by
 adding them to the extensions list in your [.node-dev.json](#settings) config
 file.
 
-__Note:__ this is a fork from fgnass/node-dev because I needed the ability to set env vars in the config file and could not wait for the changes to be merged
+__Note:__ this is a fork from [fgnass/node-dev](https://github.com/fgnass/node-dev) because I needed the ability to set env vars in the config file and could not wait for the changes to be merged
 
 ### Desktop Notifications
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ directory which – if present – overwrites the global settings.
 * __clear__ – Whether to clear the screen upon restarts. _Default:_ `false`
 * __extensions__ – Modules to load based bad on extension of the main script. _Default:_
   `{ coffee: "coffee-script", ls: "LiveScript" }`
+* __env__ – Environment key-value pairs to run the script with. _Default:_ {}
 
 ### The MIT License (MIT)
 

--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -18,5 +18,6 @@ module.exports = {
   extensions : c.extensions || {
     coffee: "coffee-script",
     ls: "LiveScript"
-  }
+  },
+  env        : c.env || {}
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,10 +37,16 @@ module.exports = function(args) {
    * Run the wrapped script.
    */
   function start() {
-    child = fork(args[0], args.slice(1), {
+    var opt = {
       cwd: process.cwd(),
       env: process.env
-    })
+    }
+
+    // Overwrite env with vars from config, if any.
+    for (var key in cfg.env)
+      if (cfg.env.hasOwnProperty(key)) opt.env[key] = cfg.env[key]
+
+    child = fork(args[0], args.slice(1), opt)
     .on('exit', function(code) {
       if (!child.respawn) process.exit(code)
       child = undefined
@@ -68,6 +74,5 @@ module.exports = function(args) {
     if (child) child.kill('SIGTERM')
     process.exit(0)
   })
-
   start()
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-dev",
+  "name": "node-dev-env",
   "version": "2.1.0",
   "description": "Restarts your app when files are modified",
   "keywords": [
@@ -12,7 +12,7 @@
   "author": "Felix Gnass",
   "repository": {
     "type": "git",
-    "url": "http://github.com/fgnass/node-dev.git"
+    "url": "http://github.com/blakevanlan/node-dev-env.git"
   },
   "license": "MIT",
   "bin": {

--- a/test/fixture/env.js
+++ b/test/fixture/env.js
@@ -1,0 +1,1 @@
+console.log(process.env.SOME_TEST_VAR)

--- a/test/test.js
+++ b/test/test.js
@@ -56,7 +56,7 @@ describe('node-dev', function() {
     run('server.coffee', done)
   })
 
-  it('should handle errors', function(done) {
+  it.only('should handle errors', function(done) {
     spawn('error.js', function(out) {
       if (out.match(/ERROR/)) {
         touchFile()

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 var child = require('child_process')
   , touch = require('touch')
   , expect = require('expect.js')
+  , fs = require('fs')
 
 var dir = __dirname + '/fixture'
   , bin = __dirname + '/../bin/node-dev'
@@ -135,6 +136,20 @@ describe('node-dev', function() {
         }, 500)
       })
       return 'kill'
+    })
+  })
+
+  it('should set env vars from config for child process', function(done) {
+    var configPath = dir + '/.node-dev.json'
+    fs.writeFileSync(configPath, '{"env":{"SOME_TEST_VAR":"something"}}')
+    expect(process.env.SOME_TEST_VAR).to.be(undefined);
+    process.nextTick(function() {
+      spawn('env.js', function(out) {
+        expect(out).to.match(/something/)
+        fs.unlinkSync(configPath)
+        done()
+        return 'kill'
+      })
     })
   })
 


### PR DESCRIPTION
This pull requests adds a new section to the existing config file that supports setting environmental variables to run the process with. My primary use case for this is when working with multiple projects who use the same environmental variables for configuration so a per directory basis for configuration is required (i.e. two separate projects have a conflicting variable such as `MONGO_URL`).

The Travis CI build has failed for this pull request but I cannot reproduce the issue. It only fails for the Node version 0.8.26 but successfully passes when tested locally with the same version. Perhaps it is a flaky test and a build restart will fix it?

Side Note: I apologies for the sloppy commits. My amending didn't quite go as planned.