### PR TITLE
initial browser live reload support

### DIFF
--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -18,5 +18,6 @@ module.exports = {
   extensions : c.extensions || {
     coffee: "coffee-script",
     ls: "LiveScript"
-  }
+  },
+  livereload: !!c.livereload
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,11 +4,13 @@ var fork = require('child_process').fork
   , notify = require('./notify')
   , cfg = require('./cfg')
   , log = require('./log')
+  , liveReload = require('./livereload')
 
 module.exports = function(args) {
 
   // The child_process
-  var child
+    var child
+    var liveReloadWS
 
   // Find the first arg that is not an option
   for (var i=0; i < args.length; i++) {
@@ -54,6 +56,9 @@ module.exports = function(args) {
       if (!child.respawn) process.exit(code)
       child = undefined
     })
+    if (liveReloadWS) {
+        liveReloadWS.broadcast('reload');
+    }
 
     // Listen for `required` messages and watch the required file.
     ipc.on(child, 'required', function(m) {
@@ -77,6 +82,11 @@ module.exports = function(args) {
     if (child) child.kill('SIGTERM')
     process.exit(0)
   })
-
+  if (cfg.livereload) {
+      liveReloadWS = liveReload();
+      if (liveReloadWS === undefined) {
+          log.warn('LiveReload server not available');
+      }
+  }
   start()
 }

--- a/lib/liveReload.js
+++ b/lib/liveReload.js
@@ -1,0 +1,94 @@
+'use strict';
+var http = require('http');
+
+// don't propagate possible ex variable - use iffy
+var WebSocketServer = (function() {
+    try {
+        return require('ws').Server;
+    } catch (ex) { }
+}());
+
+/*
+ * returns new WebSocketServer or undefined if WebSocketServer is unavailable
+ */
+function createWebSocketServer(options) {
+    var wss;
+    if (WebSocketServer !== undefined) {
+        options = options || {};
+        options.path = options.path || '/livereload';
+        options.port = options.port || 35729;
+        wss = new WebSocketServer(options);
+    }
+    return wss;
+}
+
+var PROTOCOLS = [
+    'http://livereload.com/protocols/official-7',
+    'http://livereload.com/protocols/2.x-remote-control'
+];
+
+function pushUnique(to, what) {
+    for (var i = 0; i < what.length; ++i) {
+        if (to.indexOf(what[i]) === -1) {
+            to.push(what[i]);
+        }
+    }
+    return to;
+}
+
+module.exports = function (options) {
+
+    var connections = [];
+
+    function onConnection(ws) {
+        console.log('connection');
+        function onMessage(msgString, flag) {
+            console.log('message');
+            try { var msg = JSON.parse(msgString); } catch (ex) { }
+            if (msg && msg.command === 'hello') {
+                var handshake = {
+                    command: 'hello',
+                    protocols: Object.prototype.toString.call(msg.protocols) === '[object Array]'
+                        ? pushUnique(msg.protocols, PROTOCOLS)
+                        : PROTOCOLS.slice(0),
+                    serverName: 'node-dev-livereload'
+                };
+                console.log(handshake);
+                ws.send(JSON.stringify(handshake));
+                // add to connections AFTER handshake sent
+                // and only if it's not there yet
+                if (connections.indexOf(ws === -1)) {
+                    connections.push(ws);
+                }
+            }
+        }
+        function onClose() {
+            console.log('close');
+            connections.splice(connections.indexOf(ws, 1));
+        }
+        ws.on('message', onMessage);
+        ws.on('close', onClose);
+    }
+
+    options = options || {};
+    var wsServer = options.wsServer || createWebSocketServer(options);
+    if (wsServer) {
+        wsServer.on('connection', onConnection);
+        wsServer.broadcast = function (command) {
+            console.log('broadcast');
+            var data = JSON.stringify({
+                command: command
+
+                //path: path,
+                //liveCSS: false,
+                //liveImg: false
+            });
+            for (var i = 0; i < wsServer.clients.length; ++i) {
+                console.log('to: ' + i)
+                wsServer.clients[i].send(data);
+            }
+        };
+    }
+
+    return wsServer;
+};

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "mocha": "~1.4.1",
     "expect.js": "~0.2.0",
     "coffee-script": "~1.5.0"
+  },
+  "optionalDependencies": {
+  	"ws": "~0.4"
   }
 }


### PR DESCRIPTION
Hey, I made a few changes and added support for live browser reload.

Made this because existing solutions had some issues I could not stand.

This is just an initial version, so please bare with me ... :)
I'm basically trying to find out if you're even interested to add a feature like this.
It's disabled by default.

I know adding "ws" as a dependency might be a bit overkill, so I made it at least optional.

It was originally supposed to be compatible with "LiveReload" and it's protocol-7, but when I found out how bad the browser extension was, [I wrote my own](https://github.com/jsen-/livereload-chromium). The protocol was kept, so it might be somehow compatible - not tested at all, I'm thinking about changing it anyway.
There are just two commits there so it's pretty much in early stages too.

Comments welcome.

**Edit**: I just found [https://github.com/fgnass/instant](https://github.com/fgnass/instant) ... I guess you know that one :)
I'll give it a shot and maybe use protocol of instant in the chrome-extension.