### PR TITLE
compatible with coffee-script 1.7+

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -40,8 +40,12 @@ var main = path.resolve(process.cwd(), process.argv[1])
 // Check if a module is registered for this extension
 var ext = path.extname(main).slice(1)
   , mod = cfg.extensions[ext]
+  , scriptModule = null
 
-if (mod) require(mod)
+if (mod) scriptModule = require(mod)
+
+//compatible with coffee-script 1.7+
+if (scriptModule && scriptModule.register) scriptModule.register()
 
 // Execute the wrapped script
 require(main)


### PR DESCRIPTION
compatible with coffee-script 1.7 and 1.6 at the same time.

If node-dev does not need to compatible with coffee-script 1.6, just change default coffee extension setting to `{coffee: "coffee-script/register"}`, but I think it should be compatible with older versions of coffee-script now.
