### PR TITLE
change growl to node-notify for notification support also in windows

### DIFF
--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,4 +1,4 @@
-var growl = require('growl')
+var notifier = require('node-notifier')
   , path = require('path')
   , cfg = require('./cfg')
   , log = require('./log')
@@ -9,7 +9,7 @@ var growl = require('growl')
 module.exports = function(title, msg, level) {
   level = level || 'info'
   log(title || msg, level)
-  if (cfg.notify) growl(msg, { title: title || 'node.js', image: icon(level) })
+  if (cfg.notify) notifier.notify({ title: title || 'node.js', image: icon(level), message: msg })
 }
 
 function icon(level) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dateformat": "~1.0.4-1.2.3",
     "dynamic-dedupe": "^0.2.0",
     "filewatcher": "~1.1.1",
-    "growl": "~1.7.0"
+    "node-notifier": "^4.0.2"
   },
   "devDependencies": {
     "coffee-script": "^1.8.0",


### PR DESCRIPTION
Node-notifier has better support for notifications than just growl. Actually node-notifier uses growl as fallback.
