### PR TITLE
Only use colors when stdout is a TTY

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -20,7 +20,11 @@ module.exports = function(cfg) {
   }
 
   function color(s, c) {
-    return '\x1B[' + c + 'm' + s + '\x1B[0m'
+    if (process.stdout.isTTY) {
+      return '\x1B[' + c + 'm' + s + '\x1B[0m'
+    } else {
+      return s;
+    }
   }
 
   log.info = function() {


### PR DESCRIPTION
I know I have yet to respond to your other comments. I'm sorry that I haven't yet. But in the mean time I came up with this small improvement. It improves readability when redirecting the output from node-dev to a file.