### PR TITLE
Add support for ignoring paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ server restart when changed, since it introduces an unnecessary delay.
 
 ### The MIT License (MIT)
 
-Copyright (c) 2014 Felix Gnass
+Copyright (c) 2014–2015 Felix Gnass
+Copyright (c) 2015 Daniel Gasienica
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -123,6 +123,26 @@ If your app is not listening for these signals `process.exit(0)` will be called
 immediately. If a listener is registered, node-dev assumes that your app will
 exit on its own once it is ready.
 
+### Ignore paths
+
+If you’d like to ignore certain paths or files from triggering a restart simply
+list them in the `.node-dev.json` configuration under `"ignore"`, e.g.
+
+```json
+{
+  "ignore": [
+    "client/scripts",
+    "shared/module.js"
+  ]
+}
+
+```
+
+This might be useful when you are running a [universal][universal-javascript]
+(isomorphic) web app that shares modules across the server and client, e.g.
+[React.js](react) components for server-side rendering, which you don’t want to trigger a
+server restart when changed, since it introduces an unnecessary delay.
+
 ## License
 
 ### The MIT License (MIT)
@@ -146,3 +166,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+
+[react]: http://facebook.github.io/react/
+[universal-javascript]: https://medium.com/@mjackson/universal-javascript-4761051b7ae9

--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -6,6 +6,10 @@ function read(dir) {
   return fs.existsSync(f) ? JSON.parse(fs.readFileSync(f)) : {}
 }
 
+function resolvePath(unresolvedPath) {
+  return path.resolve(process.cwd(), unresolvedPath)
+}
+
 module.exports = function(main, opts) {
   var dir = main ? path.dirname(main) : '.'
   var c = read(dir)
@@ -22,6 +26,8 @@ module.exports = function(main, opts) {
     if (opts.dedupe) c.dedupe = true
   }
 
+  var ignore = (c.ignore || []).map(resolvePath)
+
   return {
     vm         : c.vm !== false,
     fork       : c.fork !== false,
@@ -30,6 +36,7 @@ module.exports = function(main, opts) {
     timestamp  : c.timestamp || (c.timestamp !== false && 'HH:MM:ss'),
     clear      : !!c.clear,
     dedupe     : !!c.dedupe,
+    ignore     : ignore,
     extensions : c.extensions || {
       coffee: "coffee-script/register",
       ls: "LiveScript"

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,9 @@ module.exports = function(args) {
 
     // Listen for `required` messages and watch the required file.
     ipc.on(child, 'required', function(m) {
-      if (cfg.deps == -1 || getLevel(m.required) <= cfg.deps) {
+      var isIgnored = cfg.ignore.some(isPrefixOf(m.required))
+
+      if (!isIgnored && (cfg.deps == -1 || getLevel(m.required) <= cfg.deps)) {
         watcher.add(m.required)
       }
     })
@@ -106,4 +108,10 @@ function getPrefix(mod) {
   var n = 'node_modules'
   var i = mod.lastIndexOf(n)
   return ~i ? mod.slice(0, i+n.length) : ''
+}
+
+function isPrefixOf(value) {
+  return function (prefix) {
+    return value.indexOf(prefix) === 0
+  }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "watch"
   ],
   "author": "Felix Gnass",
+  "contributors": [
+    "Daniel Gasienica <daniel@gasienica.ch> (https://github.com/gasi/)"
+  ],
   "repository": {
     "type": "git",
     "url": "http://github.com/fgnass/node-dev.git"


### PR DESCRIPTION
Adds new feature that addresses #88:

> ### Ignore paths
> 
> If you’d like to ignore certain paths or files from triggering a restart simply
> list them in the `.node-dev.json` configuration under `"ignore"`, e.g.
> 
> ```json
> {
>   "ignore": [
>     "client/scripts",
>     "shared/module.js"
>   ]
> }
> 
> ```
> 
> This might be useful when you are running a [universal][universal-javascript]
> (isomorphic) web app that shares modules across the server and client, e.g.
> [React.js](react) components for server-side rendering, which you don’t want to trigger a
> server restart when changed, since it introduces an unnecessary delay.

/cc @aseemk 