### PR TITLE
Fix: --no-deps is treated as nodeArgs

### DIFF
--- a/bin/node-dev
+++ b/bin/node-dev
@@ -17,7 +17,8 @@ var devArgs = process.argv.slice(2, scriptIndex)
 
 var nodeArgs = []
 var opts = minimist(devArgs, {
-  boolean: ['all-deps', 'no-deps', 'dedupe', 'poll'],
+  boolean: ['all-deps', 'deps', 'dedupe', 'poll'],
+  default: { deps: true },
   unknown: function(arg) {
     nodeArgs.push(arg)
   }

--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -22,7 +22,7 @@ module.exports = function(main, opts) {
   if (opts) {
     // Overwrite with CLI opts ...
     if (opts.allDeps) c.deps = -1
-    if (opts.noDeps) c.deps = 0
+    if (!opts.deps) c.deps = 0
     if (opts.dedupe) c.dedupe = true
   }
 


### PR DESCRIPTION
node-dev@2.7.1 has got this issue. It will pass `--no-deps` as an argument for node rather than handle it itself.

The cause of this issue is that minimist handles `--no-` prefixes internally. So rather than declaring `no-deps` as an argument, we should be using `deps` instead.

```js
minimist(devArgs, {
  boolean: ['all-deps', 'deps', 'dedupe', 'poll'],
  default: { deps: true },
  unknown: function(arg) {
    nodeArgs.push(arg)
  }
})
```

Otherwise, when minimist parses arguments like `['--no-deps']`, it will regard `--no-deps` as an unknown argument because the argument it actually checks is `deps`, which is not defined in the `boolean` array.
