### PR TITLE
Fix `--no-verify` option

### DIFF
--- a/bin/node-dev
+++ b/bin/node-dev
@@ -31,7 +31,7 @@ var scriptArgs = process.argv.slice(scriptIndex + 1);
 var devArgs = process.argv.slice(2, scriptIndex);
 
 var opts = minimist(devArgs, {
-  boolean: ['all-deps', 'no-deps', 'dedupe', 'poll', 'respawn'],
+  boolean: ['all-deps', 'deps', 'dedupe', 'poll', 'respawn'],
   default: { deps: true },
   unknown: function (arg) {
     nodeArgs.push(arg);


### PR DESCRIPTION
Hi! Here’s what happens at the moment:

```sh
➔ node-dev --no-deps test.js
/home/tomekwi/.local/bin/node: bad option: --no-deps

➔ echo $?
9
```

This PR fixes it. No test, because I haven’t seen any tests for the CLI itself.