### PR TITLE
Add a `--no-notify` CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,15 @@ Just run `node-dev` as you would normally run `node`:
 node-dev foo.js
 ```
 
-There are two command line options that can be used to control how many files
-are watched:
+There are a couple of command line options that can be used to control which
+files are watched and what happens when they change:
 
 * `--no-deps` Watch only the project's own files and linked modules (via `npm link`)
 * `--all-deps` Watch the whole dependency tree
+* `--respawn` Keep watching for changes after the script has exited
+* `--dedupe` [Dedupe dynamically](https://www.npmjs.org/package/dynamic-dedupe)
+* `--poll` Force polling for file changes (Caution! CPU-heavy!)
+* `--no-notify` Switch off desktop notifications (see below)
 
 By default node-dev will watch all first-level dependencies, i.e. the ones in
 the project's `node_modules`folder.

--- a/bin/node-dev
+++ b/bin/node-dev
@@ -31,7 +31,7 @@ var scriptArgs = process.argv.slice(scriptIndex + 1);
 var devArgs = process.argv.slice(2, scriptIndex);
 
 var opts = minimist(devArgs, {
-  boolean: ['all-deps', 'no-deps', 'dedupe', 'poll', 'respawn'],
+  boolean: ['all-deps', 'deps', 'dedupe', 'poll', 'respawn'],
   default: { deps: true },
   unknown: function (arg) {
     nodeArgs.push(arg);

--- a/bin/node-dev
+++ b/bin/node-dev
@@ -31,7 +31,7 @@ var scriptArgs = process.argv.slice(scriptIndex + 1);
 var devArgs = process.argv.slice(2, scriptIndex);
 
 var opts = minimist(devArgs, {
-  boolean: ['all-deps', 'deps', 'dedupe', 'poll', 'respawn'],
+  boolean: ['all-deps', 'deps', 'dedupe', 'poll', 'respawn', 'notify'],
   default: { deps: true },
   unknown: function (arg) {
     nodeArgs.push(arg);

--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -27,6 +27,7 @@ module.exports = function (main, opts) {
     if (!opts.deps) c.deps = 0;
     if (opts.dedupe) c.dedupe = true;
     if (opts.respawn) c.respawn = true;
+    if (opts.notify === false) c.notify = false;
   }
 
   var ignore = (c.ignore || []).map(resolvePath);


### PR DESCRIPTION
Hi! It’s nice to be able to turn notifications on and off directly from the command line.

This PR bases off #119 to prevent a merge conflict. I’ll be happy to rebase though, if you merge #119.