### PR TITLE
Proof against weird `require.extensions`

### DIFF
--- a/lib/hook.js
+++ b/lib/hook.js
@@ -34,7 +34,7 @@ module.exports = function (cfg, wrapper, callback) {
   function updateHooks() {
     for (var ext in require.extensions) {
       var fn = require.extensions[ext];
-      if (fn.name !== 'nodeDevHook') {
+      if (typeof fn === 'function' && fn.name !== 'nodeDevHook') {
         require.extensions[ext] = createHook(fn);
       }
     }

--- a/test/fixture/modify-extensions.js
+++ b/test/fixture/modify-extensions.js
@@ -1,0 +1,1 @@
+require.extensions.bogus = undefined;

--- a/test/index.js
+++ b/test/index.js
@@ -259,3 +259,10 @@ test('should allow graceful shutdowns', function (t) {
     }
   });
 });
+
+test('should be resistant to breaking `require.extensions`', function (t) {
+  spawn('modify-extensions.js', function (out) {
+    t.notOk(/TypeError/.test(out));
+  });
+  setTimeout(t.end.bind(t), 500);
+});


### PR DESCRIPTION
Hi, I’m using node-dev to run my tests and restart them whenever I change a file. In my tests I’m using [mock-fs](https://github.com/tschaub/mock-fs) which seems to hook into `require.extensions` itself – in quite a weird way.

As a result, starting `node-dev` failed with the following message:

```js
TypeError: Cannot read property 'name' of undefined
    at updateHooks (/…/node_modules/node-dev/lib/hook.js:37:13)
```

I looked into that – the cause was a weird `{ '.coffee': undefined }` property registered at `require.extensions`.

Here’s the fix – along with a test where I’ve reproduced the problem.