### PR TITLE
Ensure method patching works when filename arguments are missing

### DIFF
--- a/lib/hook.js
+++ b/lib/hook.js
@@ -22,7 +22,9 @@ module.exports = function (cfg, wrapper, callback) {
     if (!orig) return;
     obj[method] = function () {
       var opts = arguments[optionsArgIndex];
-      var file = typeof opts == 'string' ? opts : opts.filename;
+      var file = null;
+      if(opts)
+        file = typeof opts == 'string' ? opts : opts.filename;
       if (file) callback(file);
       return orig.apply(this, arguments);
     };

--- a/test/fixture/vmtest.js
+++ b/test/fixture/vmtest.js
@@ -3,7 +3,11 @@ var fs = require('fs');
 var file = __dirname + '/log.js';
 var str = fs.readFileSync(file, 'utf8');
 
-vm.runInNewContext(str, { module: {}, require: require, console: console }, file);
+if(process.argv.length > 2 && process.argv[2] === 'nofile') {
+  vm.runInNewContext(str, { module: {}, require: require, console: console });
+} else {
+  vm.runInNewContext(str, { module: {}, require: require, console: console }, file);
+}
 
 // Listen for events to keep running
 process.on('message', function () {});

--- a/test/index.js
+++ b/test/index.js
@@ -132,6 +132,10 @@ test('should support vm functions', function (t) {
   run('vmtest.js', t.end.bind(t));
 });
 
+test('should support vm functions with missing file argument', function (t) {
+  run('vmtest.js nofile', t.end.bind(t));
+});
+
 test('should support coffee-script', function (t) {
   run('server.coffee', t.end.bind(t));
 });


### PR DESCRIPTION
Dust.js templating engine runs code via vm.runInContext without the third filename arguments, which causes property access on undefined value:

```javascript
TypeError: Cannot read property 'filename' of undefined
    at Object.obj.(anonymous function) [as runInContext] (.../node-dev/lib/hook.js:26:55)
```

To reproduce:

```javascript
var vm = require('vm');
vm.runInContext('log("hello world")', vm.createContext({log: console.log}));
```