### PR TITLE
Sometimes mod is an object, but sometimes it is a string. 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -116,9 +116,10 @@ function getLevel(mod) {
  * empty string if the path does not contain a node_modules dir.
  */
 function getPrefix(mod) {
+  var f = mod.filename || mod; // Sometimes mod is an object and sometimes a string
   var n = 'node_modules';
-  var i = mod.lastIndexOf(n);
-  return ~i ? mod.slice(0, i + n.length) : '';
+  var i = f.lastIndexOf(n);
+  return ~i ? f.slice(0, i + n.length) : '';
 }
 
 function isPrefixOf(value) {


### PR DESCRIPTION
Node-dev seems to work fine when run as `node-dev app.js`, but when I run node-dev in a _supervisorctl_ script I would get the error from #130 or #115. Even running _3.1.3_. After some investigation i noticed **mod** was sometimes an object with filename and sometimes it was a string of the filename. To cover both cases i just check to see if `mod.filename` exists, if so use it, otherwise fallback to assuming **mod** is a string.  
