### PR TITLE
Add IPC graceful shutdown option (helpful for Windows clients that can't use SIGTERM)

### DIFF
--- a/bin/node-dev
+++ b/bin/node-dev
@@ -32,7 +32,8 @@ var devArgs = process.argv.slice(2, scriptIndex);
 
 var opts = minimist(devArgs, {
   boolean: ['all-deps', 'deps', 'dedupe', 'poll', 'respawn', 'notify'],
-  default: { deps: true, notify: true },
+  string:  ['graceful_ipc'],
+  default: { deps: true, notify: true, graceful_ipc: "" },
   unknown: function (arg) {
     nodeArgs.push(arg);
   }

--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -13,7 +13,7 @@ function resolvePath(unresolvedPath) {
 module.exports = function (main, opts) {
 
   var dir = main ? path.dirname(main) : '.';
-  var c = read(dir);
+  var c = Object.assign(read(process.cwd()), read(dir));
 
   /* eslint-disable no-proto */
   c.__proto__ = read(process.env.HOME || process.env.USERPROFILE);

--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -26,6 +26,7 @@ module.exports = function (main, opts) {
     if (opts.allDeps) c.deps = -1;
     if (!opts.deps) c.deps = 0;
     if (opts.dedupe) c.dedupe = true;
+    if (opts.graceful_ipc) c.graceful_ipc = opts.graceful_ipc;
     if (opts.respawn) c.respawn = true;
     if (opts.notify === false) c.notify = false;
   }
@@ -40,6 +41,8 @@ module.exports = function (main, opts) {
     timestamp: c.timestamp || (c.timestamp !== false && 'HH:MM:ss'),
     clear: !!c.clear,
     dedupe: !!c.dedupe,
+    graceful_ipc: c.graceful_ipc,
+    ms_win: process.platform === "win32",
     ignore: ignore,
     respawn: c.respawn || false,
     extensions: c.extensions || {

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,13 +88,28 @@ module.exports = function (script, scriptArgs, nodeArgs, opts) {
 
   function stop(willTerminate) {
     child.respawn = true;
+    if (!willTerminate) {
+      if (cfg.ms_win && cfg.graceful_ipc) {
+        log.info(`Windows workaround, sending "${cfg.graceful_ipc}" message to child.`);
+        child.send(cfg.graceful_ipc);
+      } else {
+        child.kill('SIGTERM');
+      }
+    }
     child.disconnect();
-    if (!willTerminate) child.kill('SIGTERM');
   }
 
   // Relay SIGTERM
   process.on('SIGTERM', function () {
-    if (child) child.kill('SIGTERM');
+    if (child) {
+      if (cfg.ms_win && cfg.graceful_ipc) {
+        log.info(`Windows workaround, sending "${cfg.graceful_ipc}" message to child.`);
+        child.send(cfg.graceful_ipc);
+      } else {
+        child.kill('SIGTERM');
+      }
+    }
+
     process.exit(0);
   });
 

--- a/test/fixture/win_server.js
+++ b/test/fixture/win_server.js
@@ -1,0 +1,27 @@
+
+var http = require('http');
+var message = require('./message');
+
+var server = http.createServer(function (req, res) {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.write(message);
+  res.end('\n');
+});
+
+server.on('listening', function () {
+  var addr = this.address();
+  console.log('Server listening on %s:%s', addr.address, addr.port);
+  console.log(message);
+})
+.listen(0);
+
+process.on('message', function (data) {
+  if (data === "node-dev_restart") {
+    console.log("win_server.js - win restart IPC received");
+    server.close();
+  }
+});
+
+process.on('exit', function () {
+  console.log('exit');
+});


### PR DESCRIPTION
Windows clients can't use SIGTERM to gracefully shut down the app as the manager just unconditionally exits the process. Because node-dev uses fork() internally instead of spawn(), it makes it trivially simple to send the shutdown message over IPC instead of using signals. This option provides that control to the user.