### PR TITLE
Add new delay option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ files are watched and what happens when they change:
 * `--all-deps` Watch the whole dependency tree
 * `--respawn` Keep watching for changes after the script has exited
 * `--dedupe` [Dedupe dynamically](https://www.npmjs.org/package/dynamic-dedupe)
+* `--delay=<seconds>` Delay restarting by seconds to allow multiple changes to queue.
 * `--poll` Force polling for file changes (Caution! CPU-heavy!)
 * `--no-notify` Switch off desktop notifications (see below)
 
@@ -82,6 +83,7 @@ options you can set to tweak its behaviour:
 * `fork` – Whether to hook into [child_process.fork](http://nodejs.org/docs/latest/api/child_process.html#child_process_child_process_fork_modulepath_args_options) (required for [clustered](http://nodejs.org/docs/latest/api/cluster.html) programs). _Default:_ `true`
 * `deps` – How many levels of dependencies should be watched. _Default:_ `1`
 * `dedupe` – Whether modules should by [dynamically deduped](https://www.npmjs.org/package/dynamic-dedupe). _Default:_ `false`
+* `delay` - Delays the restarting of the script for the configured amount of seconds.  _Default:_ 0
 
 Upon startup node-dev looks for a `.node-dev.json` file in the user's HOME
 directory. It will also look for a `.node-dev.json` file in the same directory
@@ -143,6 +145,13 @@ Node-dev sends a `SIGTERM` signal to the child-process if a restart is required.
 If your app is not listening for these signals `process.exit(0)` will be called
 immediately. If a listener is registered, node-dev assumes that your app will
 exit on its own once it is ready.
+
+### Restart Delay
+
+For the instances where a transpiler might make changes the multiple files in
+rapid succession, a delay can be configured.  If any new changes are detected
+during the delay, the delay will be reset.   The restart will occur when no changes
+happen during `cfg.delay` seconds.
 
 ### Ignore paths
 

--- a/bin/node-dev
+++ b/bin/node-dev
@@ -32,6 +32,7 @@ var devArgs = process.argv.slice(2, scriptIndex);
 
 var opts = minimist(devArgs, {
   boolean: ['all-deps', 'deps', 'dedupe', 'poll', 'respawn', 'notify'],
+  string:  ['delay'],
   default: { deps: true, notify: true },
   unknown: function (arg) {
     nodeArgs.push(arg);

--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -26,6 +26,7 @@ module.exports = function (main, opts) {
     if (opts.allDeps) c.deps = -1;
     if (!opts.deps) c.deps = 0;
     if (opts.dedupe) c.dedupe = true;
+    if (opts.delay) c.delay = opts.delay;
     if (opts.respawn) c.respawn = true;
     if (opts.notify === false) c.notify = false;
   }
@@ -40,6 +41,7 @@ module.exports = function (main, opts) {
     timestamp: c.timestamp || (c.timestamp !== false && 'HH:MM:ss'),
     clear: !!c.clear,
     dedupe: !!c.dedupe,
+    delay: (isNaN(c.delay)) ? 0 : c.delay - 0, // Per MDN, isNaN guarantees x - 0 will work.
     ignore: ignore,
     respawn: c.respawn || false,
     extensions: c.extensions || {

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,11 +29,13 @@ module.exports = function (script, scriptArgs, nodeArgs, opts) {
   if (cfg.dedupe) process.env.NODE_DEV_PRELOAD = __dirname + '/dedupe';
 
   var watcher = filewatcher({ forcePolling: opts.poll });
+  var current_timeout_id = null;
+  var reload_child = function () {
+    current_timeout_id = null;
 
-  watcher.on('change', function (file) {
+    notify('Restarting', 'The restart timer has expired, restarting.');
     /* eslint-disable no-octal-escape */
     if (cfg.clear) process.stdout.write('\033[2J\033[H');
-    notify('Restarting', file + ' has been modified');
     watcher.removeAll();
     if (child) {
       // Child is still running, restart upon exit
@@ -43,6 +45,12 @@ module.exports = function (script, scriptArgs, nodeArgs, opts) {
       // Child is already stopped, probably due to a previous error
       start();
     }
+  }
+
+  watcher.on('change', function (file) {
+    notify('Queuing restart', file + ' has been modified');
+    if (current_timeout_id) {clearTimeout(current_timeout_id);}
+    current_timeout_id = setTimeout(reload_child, cfg.delay * 1000);
   });
 
   watcher.on('fallback', function (limit) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": ">=0.8.0"
   },
   "scripts": {
-    "test": "tap test/*.js"
+    "test": "tap -t 120 test/*.js"
   },
   "dependencies": {
     "dateformat": "~1.0.4-1.2.3",

--- a/test/index.js
+++ b/test/index.js
@@ -258,6 +258,43 @@ test('should allow graceful shutdowns', function (t) {
   });
 });
 
+test('should wait delay before restarting server', function (t) {
+  spawn('--delay=2 server.js', function (out) {
+    if (out.match(/touch message.js/)) {
+      var time1 = Date.now();
+      setTimeout(touchFile(), 500);
+      return function (out2) {
+        if (out2.match(/Restarting/)) {
+          var time2 = Date.now();
+          if ((time2 - time1) < 2000) {
+            t.fail("server must wait more than 2 seconds to restart");
+          }
+          return { exit: t.end.bind(t) };
+        }
+      };
+    }
+  });
+});
+
+test('should refresh the delay on multiple edits', function (t) {
+  spawn('--delay=3 server.js', function (out) {
+    if (out.match(/touch message.js/)) {
+      var time1 = Date.now();
+      setTimeout(touchFile(), 500);
+      setTimeout(touchFile(), 2000);
+      return function (out2) {
+        if (out2.match(/Restarting/)) {
+          var time2 = Date.now();
+          if ((time2 - time1) < 5000) {
+            t.fail("server must wait more than 5 seconds to restart");
+          }
+          return { exit: t.end.bind(t) };
+        }
+      };
+    }
+  });
+});
+
 test('should be resistant to breaking `require.extensions`', function (t) {
   spawn('modify-extensions.js', function (out) {
     t.notOk(/TypeError/.test(out));


### PR DESCRIPTION
This option allows multiple file changes to occur before node-dev
restarts itself.  Also add tests and documentation for the option.

With the addition of new tests, increase the testing timeout to 2m.
I don't know enough about TAP to fix it, but it appears the 30s timeout
is applying to the entire file, instead of individual tests.  Therefore
it needed to be increased for this checkin.