### PR TITLE
Upgrade node-notifier to fix security vulnerability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dynamic-dedupe": "^0.2.0",
     "filewatcher": "~3.0.0",
     "minimist": "^1.1.3",
-    "node-notifier": "^4.0.2",
+    "node-notifier": "^5.4.0",
     "resolve": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Running `npm audit` caused our builds to fail, and the offending package is node-notifier.  I ran tests, which passed locally.  If there's anything else I can do to verify the safety of the package upgrade, I'm happy to do it.  

Here is the report generated by `npm audit`: 

<img width="565" alt="Screen Shot 2019-04-11 at 2 40 47 PM" src="https://user-images.githubusercontent.com/1972866/55995729-1c253500-5c6a-11e9-8d91-3bb141ce93e9.png">

