### PR TITLE
Ignore package-lock.json for git and npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vagrant
 node_modules
 npm-debug.log
+package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
+package-lock.json
 test


### PR DESCRIPTION
Using a modern version of npm automatically creates a package-lock file, ignoring it for now will make it easier to update dependencies and get things up to date.