### PR TITLE
Update deprecated coffee-script to coffeescript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - 5
   - 6
+  - 8
+  - 10
+  - 11

--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -46,7 +46,7 @@ module.exports = function (main, opts) {
     ignore: ignore,
     respawn: c.respawn || false,
     extensions: c.extensions || {
-      coffee: 'coffee-script/register',
+      coffee: 'coffeescript/register',
       ls: 'LiveScript'
     }
   };

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "resolve": "^1.0.0"
   },
   "devDependencies": {
-    "coffee-script": "^1.8.0",
+    "coffeescript": "^2.4.1",
     "eslint": "^2.0.0",
     "eslint-config-airbnb-base": "^3.0.1",
     "eslint-plugin-import": "^1.8.1",

--- a/test/fixture/.node-dev.json
+++ b/test/fixture/.node-dev.json
@@ -4,7 +4,7 @@
     "./ignoredModule.js"
   ],
   "extensions": {
-    "coffee": "coffee-script/register",
+    "coffee": "coffeescript/register",
     "js": {
       "name": "./extension",
       "options": {

--- a/test/index.js
+++ b/test/index.js
@@ -130,7 +130,7 @@ test('should support vm functions with missing file argument', function (t) {
   run('vmtest.js nofile', t.end.bind(t));
 });
 
-test('should support coffee-script', function (t) {
+test('should support coffeescript', function (t) {
   run('server.coffee', t.end.bind(t));
 });
 


### PR DESCRIPTION
When installing dependencies we are greeted with the following warning:

```
npm WARN deprecated coffee-script@1.12.7: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
```

I have updated `coffee-script` to `coffeescript` along with the tests and references to it.
