### PR TITLE
Update dynamic-dedupe from v0.2.0 to v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "dateformat": "~1.0.4-1.2.3",
-    "dynamic-dedupe": "^0.2.0",
+    "dynamic-dedupe": "^0.3.0",
     "filewatcher": "~3.0.0",
     "minimist": "^1.1.3",
     "node-notifier": "^5.4.0",


### PR DESCRIPTION
When installing node-dev we are greeted with the following warning:

```
npm WARN deprecated object-keys@0.2.0: Please update to the latest object-keys
```

`object-keys` is a deprecated dependent of `dynamic-dedupe` so updating `dynamic-dedupe` to a newer version fixes the issue.
