### PR TITLE
Update devDependency tap from v5.2.0 to v12.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint": "^2.0.0",
     "eslint-config-airbnb-base": "^3.0.1",
     "eslint-plugin-import": "^1.8.1",
-    "tap": "^5.2.0",
+    "tap": "^12.6.2",
     "touch": "^1.0.0"
   }
 }


### PR DESCRIPTION
This addresses 32 known vulnerabilities in tap's dependency tree.
