### PR TITLE
Enable notify by default

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "es6": true
+  },
   "extends": [
     "airbnb-base/legacy"
   ],

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ files are watched and what happens when they change:
 * `--dedupe` [Dedupe dynamically](https://www.npmjs.org/package/dynamic-dedupe)
 * `--graceful_ipc <msg>` Send 'msg' as an IPC message instead of SIGTERM for restart/shutdown
 * `--poll` Force polling for file changes (Caution! CPU-heavy!)
-* `--no-notify` Switch off desktop notifications (see below)
 
 By default node-dev will watch all first-level dependencies, i.e. the ones in
 the project's `node_modules`folder.
@@ -83,7 +82,7 @@ options you can set to tweak its behaviour:
 * `fork` – Whether to hook into [child_process.fork](http://nodejs.org/docs/latest/api/child_process.html#child_process_child_process_fork_modulepath_args_options) (required for [clustered](http://nodejs.org/docs/latest/api/cluster.html) programs). _Default:_ `true`
 * `deps` – How many levels of dependencies should be watched. _Default:_ `1`
 * `dedupe` – Whether modules should by [dynamically deduped](https://www.npmjs.org/package/dynamic-dedupe). _Default:_ `false`
-* `graceful_ipc` - Send the argument provided as an IPC message instead of SIGTERM during restart events.  _Default:_ `""` (off)
+* `graceful_ipc` - Send the argument provided as an IPC message instead of SIGTERM during restart events. _Default:_ `""` (off)
 
 Upon startup node-dev looks for a `.node-dev.json` file in the following directories:
 * user's HOME directory
@@ -151,9 +150,9 @@ exit on its own once it is ready.
 
 Windows does not handle POSIX signals, as such signals such as `SIGTERM` cause
 the process manager to unconditionally terminate the application with no chance
-of cleanup.  In this case, the option `graceful_ipc` may be used.  If this option
+of cleanup. In this case, the option `graceful_ipc` may be used. If this option
 is defined, the argument provided to the option will be sent as an IPC message
-via `child.send("<graceful_ipc argument>")`.  The child process can listen and
+via `child.send("<graceful_ipc argument>")`. The child process can listen and
 handle this event with:
 
 ```javascript

--- a/bin/node-dev
+++ b/bin/node-dev
@@ -1,47 +1,13 @@
 #!/usr/bin/env node
 
-var dev = require('..');
-var minimist = require('minimist');
+const dev = require('../lib');
+const cli = require('../lib/cli');
 
-function getFirstNonOptionArgIndex(args) {
-  for (var i = 2; i < args.length; i++) {
-    if (args[i][0] != '-') return i;
-  }
-  return args.length;
-}
-
-function removeValueArgs(args, names) {
-  var i = 0;
-  var removed = [];
-  while (i < args.length) {
-    if (~names.indexOf(args[i])) {
-      removed = removed.concat(args.splice(i, 2));
-    } else {
-      i++;
-    }
-  }
-  return removed;
-}
-
-var nodeArgs = removeValueArgs(process.argv, ['-r', '--require']);
-
-var scriptIndex = getFirstNonOptionArgIndex(process.argv);
-var script = process.argv[scriptIndex];
-var scriptArgs = process.argv.slice(scriptIndex + 1);
-var devArgs = process.argv.slice(2, scriptIndex);
-
-var opts = minimist(devArgs, {
-  boolean: ['all-deps', 'deps', 'dedupe', 'poll', 'respawn', 'notify'],
-  string:  ['graceful_ipc'],
-  default: { deps: true, notify: true, graceful_ipc: "" },
-  unknown: function (arg) {
-    nodeArgs.push(arg);
-  }
-});
-
-if (!script) {
-  console.log('Usage: node-dev [options] script [arguments]\n');
-  process.exit(1);
-}
+const {
+  script,
+  scriptArgs,
+  nodeArgs,
+  opts
+} = cli(process.argv);
 
 dev(script, scriptArgs, nodeArgs, opts);

--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -11,7 +11,6 @@ function resolvePath(unresolvedPath) {
 }
 
 module.exports = function (main, opts) {
-
   var dir = main ? path.dirname(main) : '.';
   var c = Object.assign(read(process.cwd()), read(dir));
 
@@ -28,7 +27,7 @@ module.exports = function (main, opts) {
     if (opts.dedupe) c.dedupe = true;
     if (opts.graceful_ipc) c.graceful_ipc = opts.graceful_ipc;
     if (opts.respawn) c.respawn = true;
-    if (opts.notify === false) c.notify = false;
+    c.notify = opts.notify;
   }
 
   var ignore = (c.ignore || []).map(resolvePath);
@@ -36,7 +35,7 @@ module.exports = function (main, opts) {
   return {
     vm: c.vm !== false,
     fork: c.fork !== false,
-    notify: c.notify !== false,
+    notify: c.notify,
     deps: c.deps,
     timestamp: c.timestamp || (c.timestamp !== false && 'HH:MM:ss'),
     clear: !!c.clear,

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,0 +1,46 @@
+const minimist = require('minimist');
+
+function getFirstNonOptionArgIndex(args) {
+  for (let i = 2; i < args.length; i += 1) {
+    if (args[i][0] != '-') return i;
+  }
+  return args.length;
+}
+
+function removeValueArgs(args, names) {
+  let i = 0;
+  let removed = [];
+  while (i < args.length) {
+    if (names.includes(args[i])) {
+      removed = removed.concat(args.splice(i, 2));
+    } else {
+      i += 1;
+    }
+  }
+  return removed;
+}
+
+module.exports = function (argv) {
+  const nodeArgs = removeValueArgs(argv, ['-r', '--require']);
+
+  const scriptIndex = getFirstNonOptionArgIndex(argv);
+  const script = argv[scriptIndex];
+  const scriptArgs = argv.slice(scriptIndex + 1);
+  const devArgs = argv.slice(2, scriptIndex);
+
+  const opts = minimist(devArgs, {
+    boolean: ['all-deps', 'deps', 'dedupe', 'poll', 'respawn', 'notify'],
+    string: ['graceful_ipc'],
+    default: { deps: true, notify: true, graceful_ipc: '' },
+    unknown: function (arg) {
+      nodeArgs.push(arg);
+    }
+  });
+
+  return {
+    script,
+    scriptArgs,
+    nodeArgs,
+    opts
+  };
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,11 @@ var ipc = require('./ipc');
 var resolveMain = require('./resolveMain');
 
 module.exports = function (script, scriptArgs, nodeArgs, opts) {
+  if (!script) {
+    console.log('Usage: node-dev [options] script [arguments]\n');
+    process.exit(1);
+  }
+
   if (typeof script !== 'string' || script.length === 0) {
     throw new TypeError('`script` must be a string');
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=10"
   },
   "scripts": {
-    "lint": "eslint lib test",
+    "lint": "eslint lib test bin/node-dev",
     "test": "node test"
   },
   "dependencies": {

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,17 @@
+const tap = require('tap');
+
+const cli = require('../lib/cli.js');
+
+tap.test('notify is enabled by default', t => {
+  const { opts: { notify } } = cli([]);
+
+  t.is(notify, true);
+  t.done();
+});
+
+tap.test('notify can be disabled', t => {
+  const { opts: { notify } } = cli(['node', 'bin/node-dev', '--notify=false', 'foo.js']);
+
+  t.is(notify, false);
+  t.done();
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
+require('./cli.js');
 require('./log.js');
 require('./run.js');
 require('./spawn.js');


### PR DESCRIPTION
- Disable by passing `--notify=false`
- Move cli code out of bin
- Start testing cli interface
- Add bin to lint

I started using some es6 syntax. It makes the code much more readable in my opinion. At some point the rest of the code can be migrated.

I also tried to update `node-notifier`to `v7.0.1`, but on WSL it was very shouty and didn't work so I'll just leave it at `v5.4.0`


