### PR TITLE
v6.0.0 / 2020-10-14

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
     "airbnb-base/legacy"
   ],
   "parserOptions": {
-    "ecmaVersion": 9
+    "ecmaVersion": 11
   },
   "rules": {
     "comma-dangle": [2, "never"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # node-dev
 
+## v6.0.0 / 2020-10-14
+
+- Support ESModules in node v12.11.1+ using `get-source-loader.mjs` and `resolve-loader.mjs` for earlier versions (Fixes #212)
+- Pass all unknown arguments to node (Fixes #198)
+- Add a test case for typescript using require on the command line
+- Add a test case for coffeescript using require on the command line
+- Add a test case for `--experimental-specifier-resolution=node`
+- Add a test case for `--inspect`
+- Add `ts-node/register` as a default extension (Fixes #182)
+- [`README.md`] Updated to explain ESModule usage, node arguments, and typescript
+- [`test/utils/touch-file`] Now takes the filename as an argument
+- [`test/utils/spawn`] Also calls the callback with stderr output
+
 ## v5.2.0 / 2020-08-19
 
 - [lib/ipc.js] Do not send unless connected

--- a/README.md
+++ b/README.md
@@ -56,10 +56,12 @@ the project's `node_modules`folder.
 
 # Installation
 
-Node-dev can be installed via npm. Make sure to use the `-g` option to install
-it globally.
+`node-dev` can be installed via `npm`. Installing it with the `-g` option will
+allow you to use it anywhere you would use `node`.
 
-    npm install -g node-dev
+```
+npm install -g node-dev
+```
 
 ### Desktop Notifications
 
@@ -102,35 +104,48 @@ Upon startup node-dev looks for a `.node-dev.json` file in the following directo
 
 Settings found later in the list will overwrite previous options.
 
+### ESModules
+
+When using ESModule syntax and `.mjs` files, `node-dev` will automatically use
+a loader to know which files to watch.
+
+### Passing arguments to node
+
+From v6 onwards, `node-dev` will pass all unknown command-line arguments to
+the `node` process which should provide more flexibility for developers.
+
 ### Dedupe linked modules
 
-Sometimes you need to make sure that multiple modules get
-_exactly the same instance_ of a common (peer-) dependency. This can usually be
-achieved by running `npm dedupe` – however this doesn't work when you try to
-`npm link` a dependency (which is quite common during development). Therefore
-node-dev provides a `--dedupe` switch that will inject the
+Sometimes you need to make sure that multiple modules get _exactly the same
+instance_ of a common (peer-) dependency. This can usually be achieved by
+running `npm dedupe` – however this doesn't work when you try to `npm link` a
+dependency (which is quite common during development). Therefore `node-dev`
+provides a `--dedupe` switch that will inject the
 [dynamic-dedupe](https://www.npmjs.org/package/dynamic-dedupe) module into your
 app.
 
 ### Transpilers
 
-You can also use node-dev to run transpiled languages. You can either use a
-.js file as entry point to your application that registers your transpiler as
-require-extension manually, for example by calling `CoffeeScript.register()` or
-you can let node-dev do this for you.
+You can use `node-dev` to run transpiled languages like TypeScript. You can
+either use a `.js` file as entry point to your application that registers your
+transpiler as a require-extension manually, for example by calling
+`CoffeeScript.register()` or you can let node-dev do this for you.
 
 There is a config option called `extensions` which maps file extensions to
-compiler module names. By default this map looks like this:
+compiler module names. By default the map looks like this:
 
 ```json
     {
         "coffee": "coffee-script/register",
-        "ls": "LiveScript"
+        "ls": "LiveScript",
+        "ts": "ts-node/register"
     }
 ```
 
 This means that if you run `node-dev foo.coffee` node-dev will do a
-`require("coffee-script/register")` before running your script.
+`require("coffee-script/register")` before running your script. You will need
+to have `coffeescript` or `ts-node` installed as a dependency of your package
+for these transpilers to function.
 
 __Note:__ If you want to use coffee-script < 1.7 you have to change the
 setting to `{"coffee": "coffee-script"}`.

--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -9,7 +9,8 @@ const defaultConfig = {
   deps: 1,
   extensions: {
     coffee: 'coffeescript/register',
-    ls: 'LiveScript'
+    ls: 'LiveScript',
+    ts: 'ts-node/register'
   },
   fork: true,
   graceful_ipc: '',

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -17,23 +17,8 @@ function getFirstNonOptionArgIndex(args) {
   return args.length;
 }
 
-function removeValueArgs(args, names) {
-  let i = 0;
-  let removed = [];
-
-  while (i < args.length) {
-    if (names.includes(args[i])) {
-      removed = removed.concat(args.splice(i, 2));
-    } else {
-      i += 1;
-    }
-  }
-
-  return removed;
-}
-
-module.exports = function (argv) {
-  const nodeArgs = removeValueArgs(argv, ['-r', '--require']);
+module.exports = argv => {
+  const nodeArgs = [];
 
   const scriptIndex = getFirstNonOptionArgIndex(argv);
   const script = argv[scriptIndex];

--- a/lib/get-source-loader.mjs
+++ b/lib/get-source-loader.mjs
@@ -1,0 +1,6 @@
+import ipc from './ipc.js';
+
+export async function getSource(url, context, defaultGetSource) {
+  ipc.send({ required: new URL(url).pathname });
+  return defaultGetSource(url, context, defaultGetSource);
+}

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -1,6 +1,6 @@
 const vm = require('vm');
 
-module.exports = function (patchVM, wrapper, callback) {
+module.exports = (patchVM, wrapper, callback) => {
   // Hook into Node's `require(...)`
   updateHooks();
 
@@ -34,7 +34,7 @@ module.exports = function (patchVM, wrapper, callback) {
    * (Re-)install hooks for all registered file extensions.
    */
   function updateHooks() {
-    Object.keys(require.extensions).forEach(function (ext) {
+    Object.keys(require.extensions).forEach(ext => {
       const fn = require.extensions[ext];
       if (typeof fn === 'function' && fn.name !== 'nodeDevHook') {
         require.extensions[ext] = createHook(fn);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 const fork = require('child_process').fork;
 const filewatcher = require('filewatcher');
 const path = require('path');
+const semver = require('semver');
 
 const ipc = require('./ipc');
 const logFactory = require('./log');
@@ -48,10 +49,10 @@ module.exports = function (script, scriptArgs, nodeArgs, {
 
   const watcher = filewatcher({ forcePolling });
 
-  watcher.on('change', function (file) {
+  watcher.on('change', file => {
     /* eslint-disable no-octal-escape */
     if (clear) process.stdout.write('\033[2J\033[H');
-    notify('Restarting', file + ' has been modified');
+    notify('Restarting', `${file} has been modified`);
     watcher.removeAll();
     if (child) {
       // Child is still running, restart upon exit
@@ -63,7 +64,7 @@ module.exports = function (script, scriptArgs, nodeArgs, {
     }
   });
 
-  watcher.on('fallback', function (limit) {
+  watcher.on('fallback', limit => {
     log.warn('node-dev ran out of file handles after watching %s files.', limit);
     log.warn('Falling back to polling which uses more CPU.');
     log.info('Run ulimit -n 10000 to increase the file descriptor limit.');
@@ -75,6 +76,17 @@ module.exports = function (script, scriptArgs, nodeArgs, {
    */
   function start() {
     const cmd = nodeArgs.concat(wrapper, script, scriptArgs);
+
+    if (path.extname(script).slice(1) === 'mjs') {
+      if (semver.satisfies(process.version, '>=10 <12.11.1')) {
+        const resolveLoader = resolveMain(path.join(__dirname, 'resolve-loader.mjs'));
+        cmd.unshift('--experimental-modules', `--loader=${resolveLoader}`);
+      } else if (semver.satisfies(process.version, '>=12.11.1')) {
+        const getSourceLoader = resolveMain(path.join(__dirname, 'get-source-loader.mjs'));
+        cmd.unshift(`--experimental-loader=${getSourceLoader}`);
+      }
+    }
+
     child = fork(cmd[0], cmd.slice(1), {
       cwd: process.cwd(),
       env: process.env
@@ -83,24 +95,24 @@ module.exports = function (script, scriptArgs, nodeArgs, {
     if (respawn) {
       child.respawn = true;
     }
-    child.on('exit', function (code) {
+    child.on('exit', code => {
       if (!child.respawn) process.exit(code);
       child = undefined;
     });
 
     // Listen for `required` messages and watch the required file.
-    ipc.on(child, 'required', function (m) {
-      const isIgnored = ignore.some(isPrefixOf(m.required));
+    ipc.on(child, 'required', ({ required }) => {
+      const isIgnored = ignore.some(isPrefixOf(required));
 
-      if (!isIgnored && (deps === -1 || getLevel(m.required) <= deps)) {
-        watcher.add(m.required);
+      if (!isIgnored && (deps === -1 || getLevel(required) <= deps)) {
+        watcher.add(required);
       }
     });
 
     // Upon errors, display a notification and tell the child to exit.
-    ipc.on(child, 'error', function (m) {
-      notify(m.error, m.message, 'error');
-      stop(m.willTerminate);
+    ipc.on(child, 'error', ({ error, message, willTerminate }) => {
+      notify(error, message, 'error');
+      stop(willTerminate);
     });
   }
 
@@ -118,7 +130,7 @@ module.exports = function (script, scriptArgs, nodeArgs, {
   }
 
   // Relay SIGTERM
-  process.on('SIGTERM', function () {
+  process.on('SIGTERM', () => {
     if (child && child.connected) {
       if (gracefulIPC) {
         log.info('Sending IPC: ' + JSON.stringify(gracefulIPC));
@@ -155,7 +167,7 @@ function getPrefix(mod) {
 }
 
 function isPrefixOf(value) {
-  return function (prefix) {
+  return prefix => {
     return value.indexOf(prefix) === 0;
   };
 }

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -2,16 +2,16 @@ var path = require('path');
 var notifier = require('node-notifier');
 
 function icon(level) {
-  return path.resolve(__dirname, '../icons/node_' + level + '.png');
+  return path.resolve(__dirname, `../icons/node_${level}.png`);
 }
 
 /**
  * Displays a desktop notification and writes a message to the console.
  */
 module.exports = function (notifyEnabled, log) {
-  return function (title, msg, level) {
+  return (title, msg, level) => {
     level = level || 'info';
-    log(title || msg, level);
+    log(`${title}: ${msg}`, level);
     if (notifyEnabled) {
       notifier.notify({
         title: title || 'node.js',

--- a/lib/resolve-loader.mjs
+++ b/lib/resolve-loader.mjs
@@ -1,0 +1,11 @@
+import ipc from './ipc.js';
+
+export function resolve(specifier, parentModule, defaultResolve) {
+  const resolved = defaultResolve(specifier, parentModule);
+
+  if (parentModule) {
+    ipc.send({ required: new URL(resolved.url).pathname });
+  }
+
+  return resolved;
+}

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -18,7 +18,7 @@ if (process.env.NODE_DEV_PRELOAD) {
 }
 
 // Listen SIGTERM and exit unless there is another listener
-process.on('SIGTERM', function () {
+process.on('SIGTERM', () => {
   if (process.listeners('SIGTERM').length === 1) process.exit(0);
 });
 
@@ -26,7 +26,7 @@ if (fork) {
   // Overwrite child_process.fork() so that we can hook into forked processes
   // too. We also need to relay messages about required files to the parent.
   const originalFork = childProcess.fork;
-  childProcess.fork = function (modulePath, args, options) {
+  childProcess.fork = (modulePath, args, options) => {
     const child = originalFork(__filename, [modulePath].concat(args), options);
     ipc.relay(child);
     return child;
@@ -34,7 +34,7 @@ if (fork) {
 }
 
 // Error handler that displays a notification and logs the stack to stderr:
-process.on('uncaughtException', function (err) {
+process.on('uncaughtException', err => {
   // Sometimes uncaught exceptions are not errors
   const { message, name, stack } = err instanceof Error ? err : new Error(`uncaughtException ${err}`);
 
@@ -48,7 +48,7 @@ process.on('uncaughtException', function (err) {
 });
 
 // Hook into require() and notify the parent process about required files
-hook(vm, module, function (required) {
+hook(vm, module, required => {
   ipc.send({ required });
 });
 
@@ -70,4 +70,8 @@ if (typeof mod == 'object' && mod.name) {
 }
 
 // Execute the wrapped script
-require(main);
+if (ext === 'mjs') {
+  import(main);
+} else {
+  require(main);
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-dev",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "description": "Restarts your app when files are modified",
   "keywords": [
     "restart",
@@ -37,15 +37,19 @@
     "filewatcher": "~3.0.0",
     "minimist": "^1.1.3",
     "node-notifier": "^5.4.0",
-    "resolve": "^1.0.0"
+    "resolve": "^1.0.0",
+    "semver": "^7.3.2"
   },
   "devDependencies": {
+    "@types/node": "^14.11.8",
     "coffeescript": "^2.4.1",
-    "eslint": "^7.3.1",
+    "eslint": "^7.11.0",
     "eslint-config-airbnb-base": "^14.2.0",
-    "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-import": "^2.22.1",
     "nyc": "^15.1.0",
     "tap": "^14.10.7",
-    "touch": "^3.1.0"
+    "touch": "^3.1.0",
+    "ts-node": "^9.0.0",
+    "typescript": "^4.0.3"
   }
 }

--- a/test/fixture/.node-dev.json
+++ b/test/fixture/.node-dev.json
@@ -10,6 +10,7 @@
       "options": {
         "test": true
       }
-    }
+    },
+    "ts": "ts-node/register"
   }
 }

--- a/test/fixture/ecma-script-modules.mjs
+++ b/test/fixture/ecma-script-modules.mjs
@@ -1,0 +1,6 @@
+import message from './message.mjs';
+
+console.log(message);
+
+// So it doesn't immediately exit.
+setTimeout(() => {}, 10000);

--- a/test/fixture/experimental-specifier-resolution/index.mjs
+++ b/test/fixture/experimental-specifier-resolution/index.mjs
@@ -1,0 +1,1 @@
+export default 'experimental-specifier-resolution';

--- a/test/fixture/message.mjs
+++ b/test/fixture/message.mjs
@@ -1,0 +1,1 @@
+export default 'Please touch message.mjs now';

--- a/test/fixture/resolution.mjs
+++ b/test/fixture/resolution.mjs
@@ -1,0 +1,7 @@
+import resolution from './experimental-specifier-resolution';
+import message from './message';
+
+setTimeout(() => {}, 10000);
+
+console.log(resolution);
+console.log(message);

--- a/test/fixture/typescript/index.ts
+++ b/test/fixture/typescript/index.ts
@@ -1,0 +1,28 @@
+import { createServer, Server } from 'http';
+import * as message from '../message';
+
+const server = createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.write(message);
+  res.end('\n');
+});
+
+server.once('listening', function (this: Server) {
+  const addressInfo = this.address();
+  const address = typeof addressInfo === 'string' ? addressInfo : `${addressInfo.address}:${addressInfo.port}`;
+
+  console.log(`Server listening on ${address}`);
+  console.log(message);
+}).listen(0);
+
+process.once('SIGTERM', () => {
+  if (server.listening) {
+    server.close();
+  }
+});
+
+process.once('beforeExit', () => {
+  console.log('exit');
+});
+
+export default server;

--- a/test/run.js
+++ b/test/run.js
@@ -1,23 +1,23 @@
-var tap = require('tap');
+const tap = require('tap');
 
-var run = require('./utils/run');
+const run = require('./utils/run');
 
-tap.test('should restart the server', function (t) {
+tap.test('Restart the server', function (t) {
   run('server.js', t.end.bind(t));
 });
 
-tap.test('should restart the cluster', function (t) {
+tap.test('Restart the cluster', function (t) {
   run('cluster.js', t.end.bind(t));
 });
 
-tap.test('should support vm functions', function (t) {
+tap.test('Supports vm functions', function (t) {
   run('vmtest.js', t.end.bind(t));
 });
 
-tap.test('should support vm functions with missing file argument', function (t) {
+tap.test('Supports vm functions with missing file argument', function (t) {
   run('vmtest.js nofile', t.end.bind(t));
 });
 
-tap.test('should support coffeescript', function (t) {
+tap.test('Supports coffeescript', function (t) {
   run('server.coffee', t.end.bind(t));
 });

--- a/test/utils/run.js
+++ b/test/utils/run.js
@@ -1,19 +1,17 @@
-var spawn = require('./spawn');
-var touchFile = require('./touch-file');
+const spawn = require('./spawn');
+const touchFile = require('./touch-file');
 
-function run(cmd, done) {
-  return spawn(cmd, function (out) {
+module.exports = (cmd, exit) => {
+  return spawn(cmd, out => {
     var touched = false;
-    if (!touched && out.match(/touch message.js/)) {
-      touchFile();
+    if (!touched && out.match(/touch message\.js/)) {
+      touchFile('message.js');
       touched = true;
-      return function (out2) {
+      return out2 => {
         if (out2.match(/Restarting/)) {
-          return { exit: done };
+          return { exit };
         }
       };
     }
   });
-}
-
-module.exports = run;
+};

--- a/test/utils/spawn.js
+++ b/test/utils/spawn.js
@@ -1,16 +1,16 @@
-var child = require('child_process');
-var path = require('path');
+const child = require('child_process');
+const path = require('path');
 
-var bin = path.join(__dirname, '..', '..', 'bin', 'node-dev');
-var dir = path.join(__dirname, '..', 'fixture');
+const bin = path.join(__dirname, '..', '..', 'bin', 'node-dev');
+const dir = path.join(__dirname, '..', 'fixture');
 
-function spawn(cmd, cb) {
-  var ps = child.spawn('node', [bin].concat(cmd.split(' ')), { cwd: dir });
-  var err = '';
+module.exports = (cmd, cb) => {
+  const ps = child.spawn('node', [bin].concat(cmd.split(' ')), { cwd: dir });
+  let err = '';
 
   function errorHandler(data) {
-    console.log(data.toString());
     err += data.toString();
+    outHandler(data);
   }
 
   function exitHandler(code, signal) {
@@ -18,7 +18,7 @@ function spawn(cmd, cb) {
   }
 
   function outHandler(data) {
-    var ret = cb.call(ps, data.toString());
+    const ret = cb.call(ps, data.toString());
 
     if (typeof ret == 'function') {
       // use the returned function as new callback
@@ -26,7 +26,7 @@ function spawn(cmd, cb) {
     } else if (ret && ret.exit) {
       // kill the process and invoke the given function
       ps.removeListener('exit', exitHandler);
-      ps.once('exit', function (code) {
+      ps.once('exit', code => {
         ps.stdout.removeListener('data', outHandler);
         ps.stderr.removeListener('data', errorHandler);
         ret.exit(code);
@@ -40,6 +40,4 @@ function spawn(cmd, cb) {
   ps.stdout.on('data', outHandler);
 
   return ps;
-}
-
-module.exports = spawn;
+};

--- a/test/utils/touch-file.js
+++ b/test/utils/touch-file.js
@@ -1,17 +1,12 @@
-var path = require('path');
-var touch = require('touch');
+const path = require('path');
+const touch = require('touch');
 
-var dir = path.join(__dirname, '..', 'fixture');
-var msgFile = path.join(dir, 'message.js');
+const dir = path.join(__dirname, '..', 'fixture');
 
-// Helpers
-function touchFile() {
-  setTimeout(function () {
-    touch(msgFile);
-  // filewatcher requires a new mtime to trigger a change event
-  // but most file systems only have second precision, so wait
-  // one full second before touching.
-  }, 1000);
-}
+// filewatcher requires a new mtime to trigger a change event
+// but most file systems only have second precision, so wait
+// one full second before touching.
 
-module.exports = touchFile;
+module.exports = filename => {
+  setTimeout(() => touch(path.join(dir, filename)), 1000);
+};


### PR DESCRIPTION
- Support ESModules in node v12.11.1+ using `get-source-loader.mjs` and `resolve-loader.mjs` for earlier versions (Fixes #212)
- Pass all unknown arguments to node (Fixes #198)
- Add a test case for typescript using require on the command line
- Add a test case for coffeescript using require on the command line
- Add a test case for `--experimental-specifier-resolution=node`
- Add a test case for `--inspect`
- Add `ts-node/register` as a default extension (Fixes #182)
- [`README.md`] Updated to explain ESModule usage, node arguments, and typescript
- [`test/utils/touch-file`] Now takes the filename as an argument
- [`test/utils/spawn`] Also calls the callback with stderr output
