### PR TITLE
Fix an IPC error: the IPC could be killed too soon (#209)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -114,6 +114,14 @@ module.exports = function (script, scriptArgs, nodeArgs, {
       notify(error, message, 'error');
       stop(willTerminate);
     });
+
+    // Keep track of wether the child has loaded or not.
+    child.hasLoaded = new Promise(
+      resolve => ipc.on(child, 'loaded', () => resolve())
+    );
+    child.disconnectAfterLoaded = () => child.hasLoaded.then(
+      () => child.disconnect()
+    );
   }
 
   function stop(willTerminate) {
@@ -126,7 +134,7 @@ module.exports = function (script, scriptArgs, nodeArgs, {
         child.kill('SIGTERM');
       }
     }
-    child.disconnect();
+    child.disconnectAfterLoaded();
   }
 
   // Relay SIGTERM

--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -17,7 +17,7 @@ exports.on = function (proc, type, cb) {
 exports.relay = function (src, dest) {
   if (!dest) dest = process;
   function relayMessage(m) {
-    if (m.cmd === NODE_DEV) dest.send(m);
+    if (dest.connected && m.cmd === NODE_DEV) dest.send(m);
   }
   src.on('internalMessage', relayMessage);
   src.on('message', relayMessage);

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -75,3 +75,4 @@ if (ext === 'mjs') {
 } else {
   require(main);
 }
+ipc.send({ loaded: true });


### PR DESCRIPTION
## Description
node-dev has currenctly a bug related to IPC between the main process and the wrapper process. This can lead in bugs like: https://github.com/fgnass/node-dev/issues/209

## What happens ?
- When stopping a child, the main process will immediatly kill the IPC connection with the child

 - But if this happens before the child has the time to load, ie. to go through all the requires, the child will try to send IPC to his parent, cause the `connected` property wont be true until all the required are loaded.

- This the IPC has been terminated by the parent, this could result in a lot of error messages like "EPIPE".

## How to solves this ?

This PR solves the issue by telling the parent not to kill the connection too soon. Indeed the connection should be killed when either:
- The child is killed, but in this case the connection is terminated automatically by node.
- We want to stop the child AND the child has loaded.