### PR TITLE
Remove disconnect, pause watching while child restarts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,12 +48,14 @@ module.exports = function (script, scriptArgs, nodeArgs, {
   if (dedupe) process.env.NODE_DEV_PRELOAD = path.join(__dirname, 'dedupe');
 
   const watcher = filewatcher({ forcePolling });
+  let isPaused = false;
 
   watcher.on('change', file => {
     /* eslint-disable no-octal-escape */
     if (clear) process.stdout.write('\033[2J\033[H');
     notify('Restarting', `${file} has been modified`);
     watcher.removeAll();
+    isPaused = true;
     if (child) {
       // Child is still running, restart upon exit
       child.on('exit', start);
@@ -75,6 +77,7 @@ module.exports = function (script, scriptArgs, nodeArgs, {
    * Run the wrapped script.
    */
   function start() {
+    isPaused = false;
     const cmd = nodeArgs.concat(wrapper, script, scriptArgs);
 
     if (path.extname(script).slice(1) === 'mjs') {
@@ -102,6 +105,7 @@ module.exports = function (script, scriptArgs, nodeArgs, {
 
     // Listen for `required` messages and watch the required file.
     ipc.on(child, 'required', ({ required }) => {
+      if (isPaused) return;
       const isIgnored = ignore.some(isPrefixOf(required));
 
       if (!isIgnored && (deps === -1 || getLevel(required) <= deps)) {
@@ -126,7 +130,6 @@ module.exports = function (script, scriptArgs, nodeArgs, {
         child.kill('SIGTERM');
       }
     }
-    child.disconnect();
   }
 
   // Relay SIGTERM

--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -1,10 +1,8 @@
 const NODE_DEV = 'NODE_DEV';
 
 exports.send = function (m) {
-  if (process.connected) {
-    m.cmd = NODE_DEV;
-    process.send(m);
-  }
+  m.cmd = NODE_DEV;
+  process.send(m);
 };
 
 exports.on = function (proc, type, cb) {
@@ -16,7 +14,7 @@ exports.on = function (proc, type, cb) {
 
 exports.relay = function (src) {
   function relayMessage(m) {
-    if (process.connected && m.cmd === NODE_DEV) {
+    if (m.cmd === NODE_DEV) {
       process.send(m);
     }
   }

--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -1,22 +1,17 @@
-const NODE_DEV = 'NODE_DEV';
+const cmd = 'NODE_DEV';
 
-exports.send = function (m) {
-  m.cmd = NODE_DEV;
-  process.send(m);
+exports.send = m => {
+  if (process.connected) process.send({ ...m, cmd });
 };
 
-exports.on = function (proc, type, cb) {
-  function handleMessage(m) {
-    if (m.cmd === NODE_DEV && type in m) cb(m);
-  }
-  proc.on('internalMessage', handleMessage);
+exports.on = (src, prop, cb) => {
+  src.on('internalMessage', m => {
+    if (m.cmd === cmd && prop in m) cb(m);
+  });
 };
 
-exports.relay = function (src) {
-  function relayMessage(m) {
-    if (m.cmd === NODE_DEV) {
-      process.send(m);
-    }
-  }
-  src.on('internalMessage', relayMessage);
+exports.relay = src => {
+  src.on('internalMessage', m => {
+    if (process.connected && m.cmd === cmd) process.send(m);
+  });
 };

--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -1,9 +1,10 @@
 const NODE_DEV = 'NODE_DEV';
 
-exports.send = function (m, dest) {
-  m.cmd = NODE_DEV;
-  if (!dest) dest = process;
-  if (dest.connected) dest.send(m);
+exports.send = function (m) {
+  if (process.connected) {
+    m.cmd = NODE_DEV;
+    process.send(m);
+  }
 };
 
 exports.on = function (proc, type, cb) {
@@ -11,14 +12,13 @@ exports.on = function (proc, type, cb) {
     if (m.cmd === NODE_DEV && type in m) cb(m);
   }
   proc.on('internalMessage', handleMessage);
-  proc.on('message', handleMessage);
 };
 
-exports.relay = function (src, dest) {
-  if (!dest) dest = process;
+exports.relay = function (src) {
   function relayMessage(m) {
-    if (m.cmd === NODE_DEV) dest.send(m);
+    if (process.connected && m.cmd === NODE_DEV) {
+      process.send(m);
+    }
   }
   src.on('internalMessage', relayMessage);
-  src.on('message', relayMessage);
 };

--- a/package.json
+++ b/package.json
@@ -38,18 +38,17 @@
     "minimist": "^1.1.3",
     "node-notifier": "^5.4.0",
     "resolve": "^1.0.0",
-    "semver": "^7.3.2"
+    "semver": "^7.3.4"
   },
   "devDependencies": {
-    "@types/node": "^14.11.8",
+    "@types/node": "^14.14.31",
     "coffeescript": "^2.4.1",
-    "eslint": "^7.11.0",
-    "eslint-config-airbnb-base": "^14.2.0",
+    "eslint": "^7.20.0",
+    "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.22.1",
-    "nyc": "^15.1.0",
-    "tap": "^14.10.7",
+    "tap": "^14.11.0",
     "touch": "^3.1.0",
-    "ts-node": "^9.0.0",
-    "typescript": "^4.0.3"
+    "ts-node": "^9.1.1",
+    "typescript": "^4.1.5"
   }
 }

--- a/test/fixture/cluster.js
+++ b/test/fixture/cluster.js
@@ -19,7 +19,7 @@ if (cluster.isWorker) {
 
   process.on('disconnect', function () {
     console.log(process.pid, 'disconnect received, shutting down');
-    if (server.lisening) {
+    if (server.listening) {
       server.close();
     }
   });

--- a/test/run.js
+++ b/test/run.js
@@ -6,10 +6,6 @@ tap.test('Restart the server', function (t) {
   run('server.js', t.end.bind(t));
 });
 
-tap.test('Restart the cluster', function (t) {
-  run('cluster.js', t.end.bind(t));
-});
-
 tap.test('Supports vm functions', function (t) {
   run('vmtest.js', t.end.bind(t));
 });

--- a/test/spawn.js
+++ b/test/spawn.js
@@ -117,6 +117,27 @@ tap.test('should relay stdin', t => {
   p.stdin.write('foo');
 });
 
+tap.test('Restart the cluster', t => {
+  spawn('cluster.js', out => {
+    if (out.match(/touch message\.js/)) {
+      touchFile('message.js');
+      return out2 => {
+        if (out2.match(/Restarting/)) {
+          return out3 => {
+            if (out3.match(/All workers disconnected/)) {
+              return out4 => {
+                if (out4.match(/touch message\.js/)) {
+                  return { exit: t.end.bind(t) };
+                }
+              };
+            }
+          };
+        }
+      };
+    }
+  });
+});
+
 tap.test('should kill the forked processes', t => {
   spawn('pid.js', out => {
     const pid = parseInt(out, 10);

--- a/test/spawn.js
+++ b/test/spawn.js
@@ -164,8 +164,10 @@ tap.test('should send IPC message when configured', t => {
   spawn('--graceful_ipc=node-dev:restart ipc-server.js', out => {
     if (out.match(/touch message.js/)) {
       touchFile('message.js');
+      let shuttingDown = false;
       return out2 => {
-        if (out2.match(/IPC received/)) {
+        if (out2.match(/IPC received/) && !shuttingDown) {
+          shuttingDown = true;
           return { exit: t.end.bind(t) };
         }
       };

--- a/test/spawn.js
+++ b/test/spawn.js
@@ -119,14 +119,16 @@ tap.test('should relay stdin', t => {
 
 tap.test('Restart the cluster', t => {
   spawn('cluster.js', out => {
-    if (out.match(/touch message\.js/)) {
+    if (out.match(/touch message\.js/m)) {
       touchFile('message.js');
       return out2 => {
-        if (out2.match(/Restarting/)) {
+        if (out2.match(/Restarting/m)) {
           return out3 => {
-            if (out3.match(/All workers disconnected/)) {
+            if (out3.match(/All workers disconnected/m)) {
+              let shuttingDown = false;
               return out4 => {
-                if (out4.match(/touch message\.js/)) {
+                if (out4.match(/touch message\.js/) && !shuttingDown) {
+                  shuttingDown = true;
                   return { exit: t.end.bind(t) };
                 }
               };

--- a/test/utils/spawn.js
+++ b/test/utils/spawn.js
@@ -18,6 +18,7 @@ module.exports = (cmd, cb) => {
   }
 
   function outHandler(data) {
+    console.log(data.toString());
     const ret = cb.call(ps, data.toString());
 
     if (typeof ret == 'function') {


### PR DESCRIPTION
This should address the EPIPE errors reported in #209.

We no longer disconnect from the child processes, this avoids dealing with the hurdles of the connected state.

We also stop adding new file watchers when we know the process is shutting down.

The tests have been a bit flaky, what passes locally fails on CI. Hopefully `cluster` and `ipc` behave more consistently now.
