### PR TITLE
[Refactor] Finish converting code to ES6

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,5 +7,9 @@
   "plugins": ["import"],
   "parserOptions": {
     "ecmaVersion": 11
+  },
+  "rules": {
+    "eqeqeq": "error",
+    "prefer-arrow-callback": "error"
   }
 }

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,7 @@
+.eslintrc
+.eslintcache
 .nyc_output
+.prettierrc
+.travis.yml
 package-lock.json
 test

--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+const { existsSync, readFileSync } = require('fs');
+const { dirname, resolve } = require('path');
 
 const resolveMain = require('./resolve-main');
 
@@ -23,13 +23,13 @@ const defaultConfig = {
 };
 
 function read(dir) {
-  const f = path.resolve(dir, '.node-dev.json');
-  return fs.existsSync(f) ? JSON.parse(fs.readFileSync(f)) : {};
+  const f = resolve(dir, '.node-dev.json');
+  return existsSync(f) ? JSON.parse(readFileSync(f)) : {};
 }
 
 function getConfig(script) {
   const main = resolveMain(script);
-  const dir = main ? path.dirname(main) : '.';
+  const dir = main ? dirname(main) : '.';
 
   return Object.assign(
     defaultConfig,

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,12 +1,12 @@
 const minimist = require('minimist');
-const path = require('path');
+const { resolve } = require('path');
 
 const { defaultConfig, getConfig } = require('./cfg');
 
 const configKeys = Object.keys(defaultConfig);
 
 function resolvePath(unresolvedPath) {
-  return path.resolve(process.cwd(), unresolvedPath);
+  return resolve(process.cwd(), unresolvedPath);
 }
 
 const doubleDash = s => /^--/.test(s);

--- a/lib/get-source-loader.mjs
+++ b/lib/get-source-loader.mjs
@@ -1,6 +1,6 @@
-import ipc from './ipc.js';
+import { send } from './ipc.js';
 
 export async function getSource(url, context, defaultGetSource) {
-  ipc.send({ required: new URL(url).pathname });
+  send({ required: new URL(url).pathname });
   return defaultGetSource(url, context, defaultGetSource);
 }

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -23,7 +23,7 @@ module.exports = (patchVM, wrapper, callback) => {
       const opts = arguments[optionsArgIndex];
       let file = null;
       if (opts) {
-        file = typeof opts == 'string' ? opts : opts.filename;
+        file = typeof opts === 'string' ? opts : opts.filename;
       }
       if (file) callback(file);
       return orig.apply(this, arguments);

--- a/lib/ignore.js
+++ b/lib/ignore.js
@@ -18,7 +18,7 @@ const getPrefix = mod => {
 
 const isPrefixOf = value => prefix => value.startsWith(prefix);
 
-const configureDeps = deps => required => deps != -1 && getLevel(required) > deps;
+const configureDeps = deps => required => deps !== -1 && getLevel(required) > deps;
 const configureIgnore = ignore => required => ignore.some(isPrefixOf(required));
 
 module.exports = { configureDeps, configureIgnore };

--- a/lib/ignore.js
+++ b/lib/ignore.js
@@ -1,0 +1,24 @@
+const n = 'node_modules';
+
+/**
+ * Returns the nesting-level of the given module.
+ * Will return 0 for modules from the main package or linked modules,
+ * a positive integer otherwise.
+ */
+const getLevel = mod => getPrefix(mod).split(n).length - 1;
+
+/**
+ * Returns the path up to the last occurence of `node_modules` or an
+ * empty string if the path does not contain a node_modules dir.
+ */
+const getPrefix = mod => {
+  const i = mod.lastIndexOf(n);
+  return i !== -1 ? mod.slice(0, i + n.length) : '';
+};
+
+const isPrefixOf = value => prefix => value.startsWith(prefix);
+
+const configureDeps = deps => required => deps != -1 && getLevel(required) > deps;
+const configureIgnore = ignore => required => ignore.some(isPrefixOf(required));
+
+module.exports = { configureDeps, configureIgnore };

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,7 @@ module.exports = function (
     isPaused = false;
     const cmd = nodeArgs.concat(wrapper, script, scriptArgs);
 
-    if (extname(script).slice(1) === 'mjs') {
+    if (extname(script) === '.mjs') {
       if (semver.satisfies(process.version, '>=10 <12.11.1')) {
         const resolveLoader = resolveMain(localPath('resolve-loader.mjs'));
         cmd.unshift('--experimental-modules', `--loader=${resolveLoader}`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,14 @@
-const fork = require('child_process').fork;
+const { fork } = require('child_process');
 const filewatcher = require('filewatcher');
-const path = require('path');
+const { extname } = require('path');
 const semver = require('semver');
 
 const ipc = require('./ipc');
+const localPath = require('./local-path');
 const logFactory = require('./log');
 const notifyFactory = require('./notify');
 const resolveMain = require('./resolve-main');
+const { configureDeps, configureIgnore } = require('./ignore');
 
 module.exports = function (
   script,
@@ -47,10 +49,13 @@ module.exports = function (
   // The child_process
   let child;
 
-  const wrapper = resolveMain(path.join(__dirname, 'wrap.js'));
+  const isIgnored = configureIgnore(ignore);
+  const isTooDeep = configureDeps(deps);
+
+  const wrapper = resolveMain(localPath('wrap.js'));
 
   // Run ./dedupe.js as preload script
-  if (dedupe) process.env.NODE_DEV_PRELOAD = path.join(__dirname, 'dedupe');
+  if (dedupe) process.env.NODE_DEV_PRELOAD = localPath('dedupe');
 
   const watcher = filewatcher({ forcePolling });
   let isPaused = false;
@@ -84,12 +89,12 @@ module.exports = function (
     isPaused = false;
     const cmd = nodeArgs.concat(wrapper, script, scriptArgs);
 
-    if (path.extname(script).slice(1) === 'mjs') {
+    if (extname(script).slice(1) === 'mjs') {
       if (semver.satisfies(process.version, '>=10 <12.11.1')) {
-        const resolveLoader = resolveMain(path.join(__dirname, 'resolve-loader.mjs'));
+        const resolveLoader = resolveMain(localPath('resolve-loader.mjs'));
         cmd.unshift('--experimental-modules', `--loader=${resolveLoader}`);
       } else if (semver.satisfies(process.version, '>=12.11.1')) {
-        const getSourceLoader = resolveMain(path.join(__dirname, 'get-source-loader.mjs'));
+        const getSourceLoader = resolveMain(localPath('get-source-loader.mjs'));
         cmd.unshift(`--experimental-loader=${getSourceLoader}`);
       }
     }
@@ -102,19 +107,16 @@ module.exports = function (
     if (respawn) {
       child.respawn = true;
     }
-    child.on('exit', code => {
+
+    child.once('exit', code => {
       if (!child.respawn) process.exit(code);
+      child.removeAllListeners();
       child = undefined;
     });
 
     // Listen for `required` messages and watch the required file.
     ipc.on(child, 'required', ({ required }) => {
-      if (isPaused) return;
-      const isIgnored = ignore.some(isPrefixOf(required));
-
-      if (!isIgnored && (deps === -1 || getLevel(required) <= deps)) {
-        watcher.add(required);
-      }
+      if (!isPaused && !isIgnored(required) && !isTooDeep(required)) watcher.add(required);
     });
 
     // Upon errors, display a notification and tell the child to exit.
@@ -152,29 +154,3 @@ module.exports = function (
 
   start();
 };
-
-/**
- * Returns the nesting-level of the given module.
- * Will return 0 for modules from the main package or linked modules,
- * a positive integer otherwise.
- */
-function getLevel(mod) {
-  const p = getPrefix(mod);
-  return p.split('node_modules').length - 1;
-}
-
-/**
- * Returns the path up to the last occurence of `node_modules` or an
- * empty string if the path does not contain a node_modules dir.
- */
-function getPrefix(mod) {
-  const n = 'node_modules';
-  const i = mod.lastIndexOf(n);
-  return i !== -1 ? mod.slice(0, i + n.length) : '';
-}
-
-function isPrefixOf(value) {
-  return prefix => {
-    return value.indexOf(prefix) === 0;
-  };
-}

--- a/lib/local-path.js
+++ b/lib/local-path.js
@@ -1,0 +1,2 @@
+const { join } = require('path');
+module.exports = f => join(__dirname, f);

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,5 +1,5 @@
-const util = require('util');
-const fmt = require('dateformat');
+const { format } = require('util');
+const dateformat = require('dateformat');
 
 const colors = {
   error: '31;1',
@@ -21,7 +21,7 @@ module.exports = ({ noColor, timestamp }) => {
   const color = enableColor ? colorOutput : noop;
 
   const log = (msg, level) => {
-    const ts = timestamp ? color(fmt(new Date(), timestamp), '39') + ' ' : '';
+    const ts = timestamp ? color(dateformat(new Date(), timestamp), '39') + ' ' : '';
     const c = colors[level.toLowerCase()] || '32';
     const output = `[${color(level.toUpperCase(), c)}] ${ts}${msg}`;
     console.log(output);
@@ -30,7 +30,7 @@ module.exports = ({ noColor, timestamp }) => {
 
   const logFactory = level =>
     function () {
-      return log(util.format.apply(util, arguments), level);
+      return log(format.apply(null, arguments), level);
     };
 
   return LOG_LEVELS.reduce((log, level) => {

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,51 +1,40 @@
-var util = require('util');
-var fmt = require('dateformat');
+const util = require('util');
+const fmt = require('dateformat');
 
-var colors = {
-  info: '36',
+const colors = {
   error: '31;1',
+  info: '36',
   warn: '33'
 };
 
-function noop(s) {
-  return s;
-}
+const LOG_LEVELS = Object.keys(colors);
 
-function colorFactory(enableColor) {
-  return enableColor
-    ? function (s, c) {
-        return '\x1B[' + c + 'm' + s + '\x1B[0m';
-      }
-    : noop;
-}
+const noop = s => s;
+const colorOutput = (s, c) => '\x1B[' + c + 'm' + s + '\x1B[0m';
 
 /**
- * Logs a message to the console. The level is displayed in ANSI colors,
- * either bright red in case of an error or green otherwise.
+ * Logs a message to the console. The level is displayed in ANSI colors:
+ * errors are bright red, warnings are yellow, and info is cyan.
  */
-module.exports = function ({ noColor, timestamp }) {
-  var enableColor = !(noColor || !process.stdout.isTTY);
-  var color = colorFactory(enableColor);
+module.exports = ({ noColor, timestamp }) => {
+  const enableColor = !(noColor || !process.stdout.isTTY);
+  const color = enableColor ? colorOutput : noop;
 
-  function log(msg, level) {
-    var ts = timestamp ? color(fmt(new Date(), timestamp), '39') + ' ' : '';
-    var c = colors[level.toLowerCase()] || '32';
-    var output = '[' + color(level.toUpperCase(), c) + '] ' + ts + msg;
+  const log = (msg, level) => {
+    const ts = timestamp ? color(fmt(new Date(), timestamp), '39') + ' ' : '';
+    const c = colors[level.toLowerCase()] || '32';
+    const output = `[${color(level.toUpperCase(), c)}] ${ts}${msg}`;
     console.log(output);
     return output;
-  }
-
-  log.info = function () {
-    return log(util.format.apply(util, arguments), 'info');
   };
 
-  log.warn = function () {
-    return log(util.format.apply(util, arguments), 'warn');
-  };
+  const logFactory = level =>
+    function () {
+      return log(util.format.apply(util, arguments), level);
+    };
 
-  log.error = function () {
-    return log(util.format.apply(util, arguments), 'error');
-  };
-
-  return log;
+  return LOG_LEVELS.reduce((log, level) => {
+    log[level] = logFactory(level);
+    return log;
+  }, {});
 };

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -4,6 +4,7 @@ const localPath = require('./local-path');
 
 const iconLevelPath = level => localPath(`../icons/node_${level}.png`);
 
+// Writes a message to the console and optionally displays a desktop notification.
 module.exports = (notifyEnabled, log) => {
   return (title = 'node-dev', message, level = 'info') => {
     log(`${title}: ${message}`, level);

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -7,7 +7,7 @@ const iconLevelPath = level => localPath(`../icons/node_${level}.png`);
 // Writes a message to the console and optionally displays a desktop notification.
 module.exports = (notifyEnabled, log) => {
   return (title = 'node-dev', message, level = 'info') => {
-    log(`${title}: ${message}`, level);
+    log[level](`${title}: ${message}`);
 
     if (notifyEnabled) {
       notifier.notify({

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -4,10 +4,7 @@ const localPath = require('./local-path');
 
 const iconLevelPath = level => localPath(`../icons/node_${level}.png`);
 
-/**
- * Displays a desktop notification and writes a message to the console.
- */
-module.exports = function (notifyEnabled, log) {
+module.exports = (notifyEnabled, log) => {
   return (title = 'node-dev', message, level = 'info') => {
     log(`${title}: ${message}`, level);
 

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,22 +1,21 @@
-var path = require('path');
-var notifier = require('node-notifier');
+const notifier = require('node-notifier');
 
-function icon(level) {
-  return path.resolve(__dirname, `../icons/node_${level}.png`);
-}
+const localPath = require('./local-path');
+
+const iconLevelPath = level => localPath(`../icons/node_${level}.png`);
 
 /**
  * Displays a desktop notification and writes a message to the console.
  */
 module.exports = function (notifyEnabled, log) {
-  return (title, msg, level) => {
-    level = level || 'info';
-    log(`${title}: ${msg}`, level);
+  return (title = 'node-dev', message, level = 'info') => {
+    log(`${title}: ${message}`, level);
+
     if (notifyEnabled) {
       notifier.notify({
-        title: title || 'node.js',
-        icon: icon(level),
-        message: msg
+        title,
+        icon: iconLevelPath(level),
+        message
       });
     }
   };

--- a/lib/resolve-loader.mjs
+++ b/lib/resolve-loader.mjs
@@ -1,4 +1,6 @@
-import { send } from './ipc.js';
+import ipc from './ipc.js';
+
+const { send } = ipc;
 
 export function resolve(specifier, parentModule, defaultResolve) {
   const resolved = defaultResolve(specifier, parentModule);

--- a/lib/resolve-loader.mjs
+++ b/lib/resolve-loader.mjs
@@ -1,10 +1,10 @@
-import ipc from './ipc.js';
+import { send } from './ipc.js';
 
 export function resolve(specifier, parentModule, defaultResolve) {
   const resolved = defaultResolve(specifier, parentModule);
 
   if (parentModule) {
-    ipc.send({ required: new URL(resolved.url).pathname });
+    send({ required: new URL(resolved.url).pathname });
   }
 
   return resolved;

--- a/lib/resolve-main.js
+++ b/lib/resolve-main.js
@@ -1,8 +1,7 @@
-var resolve = require('resolve').sync;
+const { sync: resolve } = require('resolve');
 
-module.exports = function (main) {
-  return resolve(main, {
-    basedir: process.cwd(),
-    paths: [process.cwd()]
-  });
+module.exports = main => {
+  const basedir = process.cwd();
+  const paths = [basedir];
+  return resolve(main, { basedir, paths });
 };

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -1,6 +1,6 @@
-const path = require('path');
+const { dirname, extname } = require('path');
 const childProcess = require('child_process');
-const resolve = require('resolve').sync;
+const { sync: resolve } = require('resolve');
 
 const { getConfig } = require('./cfg');
 const hook = require('./hook');
@@ -63,9 +63,9 @@ hook(vm, module, required => {
 
 // Check if a module is registered for this extension
 const main = resolveMain(script);
-const ext = path.extname(main).slice(1);
+const ext = extname(main).slice(1);
 const mod = extensions[ext];
-const basedir = path.dirname(main);
+const basedir = dirname(main);
 
 // Support extensions where 'require' returns a function that accepts options
 if (typeof mod == 'object' && mod.name) {

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -17,18 +17,8 @@ if (process.env.NODE_DEV_PRELOAD) {
   require(process.env.NODE_DEV_PRELOAD);
 }
 
-// Listen to SIGTERM ...
-const onSIGTERM = () => {
-  if (process.listeners('SIGTERM').length === 1) {
-    // We are the only listener, exit right away.
-    process.exit(0);
-  } else {
-    // Remove ourself from the list of listeners so that the other listener
-    // doesn't think it has to wait for us.
-    process.off('SIGTERM', onSIGTERM);
-  }
-};
-process.on('SIGTERM', onSIGTERM);
+// We want to exit on SIGTERM, but defer to existing SIGTERM handlers.
+process.once('SIGTERM', () => process.listenerCount('SIGTERM') || process.exit(0));
 
 if (fork) {
   // Overwrite child_process.fork() so that we can hook into forked processes

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -68,13 +68,13 @@ const mod = extensions[ext];
 const basedir = dirname(main);
 
 // Support extensions where 'require' returns a function that accepts options
-if (typeof mod == 'object' && mod.name) {
+if (typeof mod === 'object' && mod.name) {
   const fn = require(resolve(mod.name, { basedir }));
-  if (typeof fn == 'function' && mod.options) {
+  if (typeof fn === 'function' && mod.options) {
     // require returned a function, call it with options
     fn(mod.options);
   }
-} else if (typeof mod == 'string') {
+} else if (typeof mod === 'string') {
   require(resolve(mod, { basedir }));
 }
 

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -47,9 +47,7 @@ process.on('uncaughtException', err => {
 });
 
 // Hook into require() and notify the parent process about required files
-hook(vm, module, required => {
-  ipc.send({ required });
-});
+hook(vm, module, required => ipc.send({ required }));
 
 // Check if a module is registered for this extension
 const main = resolveMain(script);

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -4,7 +4,7 @@ const { sync: resolve } = require('resolve');
 
 const { getConfig } = require('./cfg');
 const hook = require('./hook');
-const ipc = require('./ipc');
+const { relay, send } = require('./ipc');
 const resolveMain = require('./resolve-main');
 
 // Remove wrap.js from the argv array
@@ -26,7 +26,7 @@ if (fork) {
   const originalFork = childProcess.fork;
   childProcess.fork = (modulePath, args, options) => {
     const child = originalFork(__filename, [modulePath].concat(args), options);
-    ipc.relay(child);
+    relay(child);
     return child;
   };
 }
@@ -41,13 +41,13 @@ process.on('uncaughtException', err => {
 
   // If there's a custom uncaughtException handler expect it to terminate
   // the process.
-  const willTerminate = process.listeners('uncaughtException').length > 1;
+  const willTerminate = process.listenerCount('uncaughtException') > 1;
 
-  ipc.send({ error: name, message, willTerminate });
+  send({ error: name, message, willTerminate });
 });
 
 // Hook into require() and notify the parent process about required files
-hook(vm, module, required => ipc.send({ required }));
+hook(vm, module, required => send({ required }));
 
 // Check if a module is registered for this extension
 const main = resolveMain(script);
@@ -67,8 +67,4 @@ if (typeof mod === 'object' && mod.name) {
 }
 
 // Execute the wrapped script
-if (ext === 'mjs') {
-  import(main);
-} else {
-  require(main);
-}
+ext === 'mjs' ? import(main) : require(main);

--- a/test/fixture/ipc-server.js
+++ b/test/fixture/ipc-server.js
@@ -1,31 +1,32 @@
-var http = require('http');
-var message = require('./message');
+const { createServer } = require('http');
 
-var server = http.createServer(function (req, res) {
+const message = require('./message');
+
+const server = createServer((req, res) => {
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.write(message);
   res.end('\n');
 });
 
 server
-  .on('listening', function () {
-    var addr = this.address();
-    console.log('Server listening on %s:%s', addr.address, addr.port);
+  .on('listening', () => {
+    const { address, port } = server.address();
+    console.log(`Server listening on ${address}:${port}`);
     console.log(message);
   })
   .listen(0);
 
-process.on('message', function (data) {
+process.on('message', data => {
   if (data === 'node-dev:restart') {
     console.log('ipc-server.js - IPC received');
     server.close();
   }
 });
 
-process.on('exit', function () {
+process.once('beforeExit', () => {
   console.log('exit');
 });
 
-process.on('SIGTERM', function () {
-  server.close();
+process.once('SIGTERM', () => {
+  if (server.listening) server.close();
 });

--- a/test/fixture/ipc-server.js
+++ b/test/fixture/ipc-server.js
@@ -23,9 +23,7 @@ process.on('message', data => {
   }
 });
 
-process.once('beforeExit', () => {
-  console.log('exit');
-});
+process.once('beforeExit', () => console.log('exit'));
 
 process.once('SIGTERM', () => {
   if (server.listening) server.close();

--- a/test/fixture/main.js
+++ b/test/fixture/main.js
@@ -1,1 +1,1 @@
-process.exit(module == require.main ? 0 : 1);
+process.exit(module === require.main ? 0 : 1);

--- a/test/fixture/pid.js
+++ b/test/fixture/pid.js
@@ -1,5 +1,3 @@
-require('http').createServer().listen(0);
+const server = require('http').createServer().listen(0);
 console.log(process.pid);
-process.on('SIGTERM', function () {
-  process.exit();
-});
+process.once('SIGTERM', () => server.close());

--- a/test/fixture/server.js
+++ b/test/fixture/server.js
@@ -1,31 +1,28 @@
-var http = require('http');
-var message = require('./message');
+const { createServer } = require('http');
+
+const message = require('./message');
 
 // Changes to this module should not cause a server restart:
 require('./ignored-module');
 
-var server = http.createServer(function (req, res) {
+const server = createServer((req, res) => {
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.write(message);
   res.end('\n');
 });
 
 server
-  .once('listening', function () {
-    var addr = this.address();
-    console.log('Server listening on %s:%s', addr.address, addr.port);
+  .once('listening', () => {
+    const { address, port } = server.address();
+    console.log('Server listening on %s:%s', address, port);
     console.log(message);
   })
   .listen(0);
 
-process.once('SIGTERM', function () {
-  if (server.listening) {
-    server.close();
-  }
+process.once('SIGTERM', () => {
+  if (server.listening) server.close();
 });
 
-process.once('beforeExit', function () {
-  console.log('exit');
-});
+process.once('beforeExit', () => console.log('exit'));
 
 module.exports = server;

--- a/test/fixture/typescript/index.ts
+++ b/test/fixture/typescript/index.ts
@@ -1,4 +1,5 @@
-import { createServer, Server } from 'http';
+import { createServer } from 'http';
+
 import * as message from '../message';
 
 const server = createServer((req, res) => {
@@ -7,16 +8,14 @@ const server = createServer((req, res) => {
   res.end('\n');
 });
 
-server
-  .once('listening', function (this: Server) {
-    const addressInfo = this.address();
-    const address =
-      typeof addressInfo === 'string' ? addressInfo : `${addressInfo.address}:${addressInfo.port}`;
+server.once('listening', () => {
+  const addressInfo = server.address();
+  const address = typeof addressInfo === 'string' ?
+    addressInfo : `${addressInfo.address}:${addressInfo.port}`;
 
-    console.log(`Server listening on ${address}`);
-    console.log(message);
-  })
-  .listen(0);
+  console.log(`Server listening on ${address}`);
+  console.log(message);
+}).listen(0);
 
 process.once('SIGTERM', () => {
   if (server.listening) {
@@ -24,8 +23,6 @@ process.once('SIGTERM', () => {
   }
 });
 
-process.once('beforeExit', () => {
-  console.log('exit');
-});
+process.once('beforeExit', () => console.log('exit'));
 
 export default server;

--- a/test/fixture/uncaught-exception-handler.js
+++ b/test/fixture/uncaught-exception-handler.js
@@ -1,7 +1,5 @@
-process.on('uncaughtException', function (e) {
-  setTimeout(function () {
-    console.log('async', e);
-  }, 100);
+process.on('uncaughtException', e => {
+  setTimeout(() => console.log('async', e), 100);
 });
 
 // eslint-disable-next-line no-undef

--- a/test/fixture/vmtest.js
+++ b/test/fixture/vmtest.js
@@ -1,8 +1,10 @@
-var fs = require('fs');
-var path = require('path');
-var vm = require('vm');
-var file = path.join(__dirname, 'log.js');
-var str = fs.readFileSync(file, 'utf8');
+const { readFileSync } = require('fs');
+const server = require('http').createServer().listen(0);
+const { join } = require('path');
+const vm = require('vm');
+
+const file = join(__dirname, 'log.js');
+const str = readFileSync(file, 'utf8');
 
 if (process.argv.length > 2 && process.argv[2] === 'nofile') {
   vm.runInNewContext(str, { module: {}, require: require, console: console });
@@ -10,15 +12,6 @@ if (process.argv.length > 2 && process.argv[2] === 'nofile') {
   vm.runInNewContext(str, { module: {}, require: require, console: console }, file);
 }
 
-function noop() {}
+process.once('SIGTERM', () => server.close());
 
-// Listen for events to keep running
-process.on('message', noop);
-
-process.on('SIGTERM', function () {
-  process.removeListener('message', noop);
-});
-
-process.on('exit', function () {
-  console.log('exit');
-});
+process.once('beforeExit', () => console.log('exit'));

--- a/test/log.js
+++ b/test/log.js
@@ -5,31 +5,31 @@ const logFactory = require('../lib/log');
 
 const noColorCfg = { ...defaultConfig, noColor: true };
 
-tap.test('log.info', function (t) {
+tap.test('log.info', t => {
   const log = logFactory(noColorCfg);
   t.like(log.info('hello'), /\[INFO\] \d{2}:\d{2}:\d{2} hello/);
   t.done();
 });
 
-tap.test('log.warn', function (t) {
+tap.test('log.warn', t => {
   const log = logFactory(noColorCfg);
   t.like(log.warn('a warning'), /\[WARN\] \d{2}:\d{2}:\d{2} a warning/);
   t.done();
 });
 
-tap.test('log.error', function (t) {
+tap.test('log.error', t => {
   const log = logFactory(noColorCfg);
   t.like(log.error('an error'), /\[ERROR\] \d{2}:\d{2}:\d{2} an error/);
   t.done();
 });
 
-tap.test('Disable the timestamp', function (t) {
+tap.test('Disable the timestamp', t => {
   const log = logFactory({ ...noColorCfg, timestamp: false });
   t.like(log.info('no timestamp'), /\[INFO\] no timestamp/);
   t.done();
 });
 
-tap.test('Custom timestamp', function (t) {
+tap.test('Custom timestamp', t => {
   const log = logFactory({ ...noColorCfg, timestamp: 'yyyy-mm-dd HH:MM:ss' });
   t.like(log.error('an error'), /\[ERROR\] \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} an error/);
   t.done();

--- a/test/run.js
+++ b/test/run.js
@@ -2,14 +2,14 @@ const tap = require('tap');
 
 const run = require('./utils/run');
 
-tap.test('Restart the server', function (t) {
+tap.test('Restart the server', t => {
   run('server.js', t.end.bind(t));
 });
 
-tap.test('Supports vm functions', function (t) {
+tap.test('Supports vm functions', t => {
   run('vmtest.js', t.end.bind(t));
 });
 
-tap.test('Supports vm functions with missing file argument', function (t) {
+tap.test('Supports vm functions with missing file argument', t => {
   run('vmtest.js nofile', t.end.bind(t));
 });

--- a/test/utils/run.js
+++ b/test/utils/run.js
@@ -3,7 +3,7 @@ const touchFile = require('./touch-file');
 
 module.exports = (cmd, exit) => {
   return spawn(cmd, out => {
-    var touched = false;
+    let touched = false;
     if (!touched && out.match(/touch message\.js/)) {
       touchFile('message.js');
       touched = true;

--- a/test/utils/spawn.js
+++ b/test/utils/spawn.js
@@ -21,7 +21,7 @@ module.exports = (cmd, cb) => {
     console.log(data.toString());
     const ret = cb.call(ps, data.toString());
 
-    if (typeof ret == 'function') {
+    if (typeof ret === 'function') {
       // use the returned function as new callback
       cb = ret;
     } else if (ret && ret.exit) {

--- a/test/utils/touch-file.js
+++ b/test/utils/touch-file.js
@@ -1,12 +1,12 @@
-const path = require('path');
+const { join } = require('path');
 const touch = require('touch');
 
-const dir = path.join(__dirname, '..', 'fixture');
+const dir = join(__dirname, '..', 'fixture');
 
 // filewatcher requires a new mtime to trigger a change event
 // but most file systems only have second precision, so wait
 // one full second before touching.
 
 module.exports = filename => {
-  setTimeout(() => touch(path.join(dir, filename)), 1000);
+  setTimeout(() => touch(join(dir, filename)), 1000);
 };


### PR DESCRIPTION
- [.npmignore] We can ignore some dotfiles that aren't necessary for the module to function
- Prefer extracting only the method names from modules that we require, this is a preparatory step for switching to import statements and enables tree shaking.
- Prefer using triple equals instead of double.
- Prefer using arrow functions
- [lib/ignore.js] Move ignore logic into its own file
- [lib/local-path.js] Move local path function into its own file
- [lib/log.js] Convert to ES6
- [lib/notify.js] Convert to ES6
- [test] Finish converting to ES6 style code
