### PR TITLE
Add tree-kill option

### DIFF
--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -21,6 +21,7 @@ const defaultConfig = {
   poll: false,
   respawn: false,
   timestamp: 'HH:MM:ss',
+  tree_kill: false,
   vm: true
 };
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -41,9 +41,13 @@ module.exports = argv => {
   const devArgs = argv.slice(2, scriptIndex);
 
   const opts = minimist(devArgs, {
-    boolean: ['clear', 'dedupe', 'fork', 'notify', 'poll', 'respawn', 'vm'],
-    string: ['graceful_ipc', 'ignore', 'timestamp'],
+    boolean: ['clear', 'dedupe', 'fork', 'notify', 'poll', 'respawn', 'vm', 'tree_kill'],
+    string: ['graceful_ipc', 'debounce', 'ignore', 'interval', 'timestamp'],
     default: getConfig(script),
+    alias: {
+      tree_kill: ['tree-kill'],
+      graceful_ipc: ['graceful-ipc']
+    },
     unknown: arg => {
       const key = Object.keys(minimist([arg]))[1];
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -42,7 +42,7 @@ module.exports = argv => {
 
   const opts = minimist(devArgs, {
     boolean: ['clear', 'dedupe', 'fork', 'notify', 'poll', 'respawn', 'vm', 'tree_kill'],
-    string: ['graceful_ipc', 'debounce', 'ignore', 'interval', 'timestamp'],
+    string: ['graceful_ipc', 'ignore', 'timestamp'],
     default: getConfig(script),
     alias: {
       tree_kill: ['tree-kill'],

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ const { fork } = require('child_process');
 const filewatcher = require('filewatcher');
 const { extname } = require('path');
 const semver = require('semver');
+const treeKill = require('tree-kill');
 
 const { clearFactory } = require('./clear');
 const { configureDeps, configureIgnore } = require('./ignore');
@@ -26,7 +27,8 @@ module.exports = function (
     notify: notifyEnabled,
     poll: forcePolling,
     respawn,
-    timestamp
+    timestamp,
+    tree_kill
   }
 ) {
   if (!script) {
@@ -72,8 +74,7 @@ module.exports = function (
     isPaused = true;
     if (child) {
       // Child is still running, restart upon exit
-      child.on('exit', start);
-      stop();
+      stop(false, start);
     } else {
       // Child is already stopped, probably due to a previous error
       start();
@@ -131,14 +132,21 @@ module.exports = function (
     });
   }
 
-  function stop(willTerminate) {
+  function stop(willTerminate, cb) {
     child.respawn = true;
     if (!willTerminate) {
+      if (cb && !tree_kill) {
+        child.on('exit', cb);
+      }
       if (gracefulIPC) {
         log.info('Sending IPC: ' + JSON.stringify(gracefulIPC));
         child.send(gracefulIPC);
       } else {
-        child.kill('SIGTERM');
+        if (tree_kill) {
+          treeKill(child.pid, 'SIGTERM', cb);
+        } else {
+          child.kill('SIGTERM');
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "minimist": "^1.1.3",
     "node-notifier": "^8.0.1",
     "resolve": "^1.0.0",
-    "semver": "^7.3.5"
+    "semver": "^7.3.4",
+    "tree-kill": "^1.2.2"
   },
   "devDependencies": {
     "@types/node": "^14.14.37",


### PR DESCRIPTION
This adds dependency [`tree-kill`](https://github.com/pkrumins/node-tree-kill) and boolean option `--tree-kill`

Though there is a test that checks if a child spawned should be killed it is not always the case, even for standard HTTP servers, I met situations where processes after a restart are not killed (and the new run process can not start server because the port is taken). Using tree-kill is actually solves this problem as well as for heavier processes (like chromium headless for example).


Also it would be good if tests were run without actual output. And probably it is better to replace `tap` with `tape` (at least to be able use `test.only` while development).