### PR TITLE
Correction in README about extraneous command-line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ There are a couple of command-line options that can be used to control which fil
 
 ## Passing arguments to node
 
-All command-line arguments that are no `node-dev` options are passed on to the `node` process.
+The command-line arguments "--inspect" and "--inspect-brk" will be passed on to the `node` process. All other unrecognized arguments will result in an AssertionError and the process will terminate with a non-zero exit code.
 
 # Installation
 


### PR DESCRIPTION
There was a statement in the README about command-line arguments that are not node-dev options "are passed on to the node process."

In practice this is not the case and passing Node arguments such as `--preserve-symlinks` results in the process exiting with an AssertionError (see screenshot below).

### Screenshot
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/369384/156674084-61a47174-60a1-4ee5-8704-7a3ab80574b1.png">
