### PR TITLE
[ESM] Detect modules with get-package-type (#201)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,5 +13,13 @@
     "no-trailing-spaces": "error",
     "prefer-arrow-callback": "error",
     "semi": "error"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["./**/*.mjs"],
+      "parserOptions": {
+        "sourceType": "module"
+      }
+    }
+  ]
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ const { fork } = require('child_process');
 const filewatcher = require('filewatcher');
 const { extname } = require('path');
 const semver = require('semver');
+const getPackageType = require('get-package-type');
 
 const { clearFactory } = require('./clear');
 const { configureDeps, configureIgnore } = require('./ignore');
@@ -94,7 +95,7 @@ module.exports = function (
     isPaused = false;
     const cmd = nodeArgs.concat(wrapper, script, scriptArgs);
 
-    if (extname(script) === '.mjs') {
+    if (extname(script) === '.mjs' || getPackageType.sync(script) === 'module') {
       if (semver.satisfies(process.version, '>=10 <12.11.1')) {
         const resolveLoader = resolveMain(localPath('resolve-loader.mjs'));
         cmd.unshift('--experimental-modules', `--loader=${resolveLoader}`);

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -1,6 +1,7 @@
 const { dirname, extname } = require('path');
 const childProcess = require('child_process');
 const { sync: resolve } = require('resolve');
+const getPackageType = require('get-package-type');
 
 const { getConfig } = require('./cfg');
 const hook = require('./hook');
@@ -67,4 +68,4 @@ if (typeof mod === 'object' && mod.name) {
 }
 
 // Execute the wrapped script
-ext === 'mjs' ? import(main) : require(main);
+ext === 'mjs' || getPackageType.sync(main) === 'module' ? import(main) : require(main);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "dateformat": "^3.0.3",
     "dynamic-dedupe": "^0.3.0",
     "filewatcher": "~3.0.0",
+    "get-package-type": "^0.1.0",
     "minimist": "^1.2.5",
     "node-notifier": "^8.0.1",
     "resolve": "^1.0.0",

--- a/test/fixture/ecma-script-module-package/.eslintrc
+++ b/test/fixture/ecma-script-module-package/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/test/fixture/ecma-script-module-package/.node-dev.json
+++ b/test/fixture/ecma-script-module-package/.node-dev.json
@@ -1,0 +1,3 @@
+{
+  "extensions": {}
+}

--- a/test/fixture/ecma-script-module-package/index.js
+++ b/test/fixture/ecma-script-module-package/index.js
@@ -1,0 +1,6 @@
+import message from './message.js';
+
+console.log(message);
+
+// So it doesn't immediately exit.
+setTimeout(() => {}, 10000);

--- a/test/fixture/ecma-script-module-package/message.js
+++ b/test/fixture/ecma-script-module-package/message.js
@@ -1,0 +1,1 @@
+export default 'Please touch ecma-script-module-package/message.js now';

--- a/test/fixture/ecma-script-module-package/package.json
+++ b/test/fixture/ecma-script-module-package/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/spawn/esmodule.js
+++ b/test/spawn/esmodule.js
@@ -35,3 +35,19 @@ tap.test('Supports ECMAScript modules', t => {
     }
   });
 });
+
+tap.test('Supports ECMAScript module packages', t => {
+  if (process.platform === 'win32') return t.skip('ESM support on windows is broken');
+
+  spawn('ecma-script-module-package/index.js', out => {
+    if (out.match(/touch ecma-script-module-package\/message.js/)) {
+      touchFile('ecma-script-module-package/message.js');
+      return out2 => {
+        if (out2.match(/Restarting/)) {
+          t.match(out2, /\[INFO\] \d{2}:\d{2}:\d{2} Restarting/);
+          return { exit: t.end.bind(t) };
+        }
+      };
+    }
+  });
+});


### PR DESCRIPTION
I noticed that the only way to load scripts in module mode is by explicitly adding the `.mjs` extension. With this PR, the `type` setting in a project's `package.json` file is also consulted. This will be more and more the way ESM-only projects are to be identified.