### PR TITLE
Move extension options config test into it's own folder

### DIFF
--- a/lib/get-source-loader.mjs
+++ b/lib/get-source-loader.mjs
@@ -1,4 +1,4 @@
-import { send } from './ipc.js';
+import { send } from './ipc.mjs';
 
 export async function getSource(url, context, defaultGetSource) {
   send({ required: new URL(url).pathname });

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,6 +101,9 @@ module.exports = function (
         const resolveLoader = resolveMain(localPath('resolve-loader.mjs'));
         args.push('--experimental-modules', `--loader=${resolveLoader}`);
       } else if (semver.satisfies(process.version, '>=12.11.1')) {
+        if (semver.satisfies(process.version, '<12.17.0')) {
+          args.push('--experimental-modules');
+        }
         const loaderPath = semver.satisfies(process.version, '>=16.12.0')
           ? 'load-loader.mjs'
           : 'get-source-loader.mjs';

--- a/lib/ipc.mjs
+++ b/lib/ipc.mjs
@@ -1,0 +1,17 @@
+const cmd = 'NODE_DEV';
+
+export const send = m => {
+  if (process.connected) process.send({ ...m, cmd });
+};
+
+export const on = (src, prop, cb) => {
+  src.on('internalMessage', m => {
+    if (m.cmd === cmd && prop in m) cb(m);
+  });
+};
+
+export const relay = src => {
+  src.on('internalMessage', m => {
+    if (process.connected && m.cmd === cmd) process.send(m);
+  });
+};

--- a/test/fixture/.node-dev.json
+++ b/test/fixture/.node-dev.json
@@ -2,12 +2,6 @@
   "notify": false,
   "ignore": ["./ignored-module.js"],
   "extensions": {
-    "js": {
-      "name": "./extension",
-      "options": {
-        "test": true
-      }
-    },
     "ts": "ts-node/register"
   }
 }

--- a/test/fixture/ecma-script-module-package/.node-dev.json
+++ b/test/fixture/ecma-script-module-package/.node-dev.json
@@ -1,3 +1,0 @@
-{
-  "extensions": {}
-}

--- a/test/fixture/extension-options/.node-dev.json
+++ b/test/fixture/extension-options/.node-dev.json
@@ -1,0 +1,10 @@
+{
+  "extensions": {
+    "js": {
+      "name": "./extension.js",
+      "options": {
+        "test": true
+      }
+    }
+  }
+}

--- a/test/fixture/extension-options/extension.js
+++ b/test/fixture/extension-options/extension.js
@@ -6,4 +6,5 @@ module.exports = function (options) {
   if (options.test !== true) {
     throw new Error('Expected options.test to be true');
   }
+  console.log(options);
 };

--- a/test/fixture/extension-options/index.js
+++ b/test/fixture/extension-options/index.js
@@ -1,0 +1,6 @@
+const message = require('../message.js');
+
+console.log(message);
+
+// So it doesn't immediately exit.
+setTimeout(() => {}, 10000);

--- a/test/spawn/extension-options.js
+++ b/test/spawn/extension-options.js
@@ -1,0 +1,9 @@
+const tap = require('tap');
+
+const { spawn } = require('../utils');
+
+tap.test('should pass options to extensions according to .node-dev.json', t => {
+  spawn('extension-options', out => {
+    if (out.match(/\{ test: true \}/)) return { exit: t.end.bind(t) };
+  });
+});

--- a/test/spawn/index.js
+++ b/test/spawn/index.js
@@ -8,6 +8,7 @@ require('./errors');
 require('./esmodule');
 require('./exit-code');
 require('./expose-gc');
+require('./extension-options');
 require('./graceful-ipc');
 require('./inspect');
 require('./kill-fork');


### PR DESCRIPTION
It shouldn't be necessary to remove the extensions from `.node-dev.json` because the path resolution doesn't work correctly.

Additionally, added an `ipc.mjs` to use in `get-source-loader` because module.exports didn't work in node v12.16