### PR TITLE
[ESM] Support wrapping a custom loader

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,7 @@
     {
       "files": ["./**/*.mjs"],
       "parserOptions": {
+        "ecmaVersion": 13,
         "sourceType": "module"
       }
     }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -16,7 +16,7 @@ const nodeString = ['require'];
 
 const nodeDevBoolean = ['clear', 'dedupe', 'fork', 'notify', 'poll', 'respawn', 'vm'];
 const nodeDevNumber = ['debounce', 'deps', 'interval'];
-const nodeDevString = ['graceful_ipc', 'ignore', 'timestamp'];
+const nodeDevString = ['graceful_ipc', 'ignore', 'timestamp', 'experimental-loader'];
 
 const alias = Object.assign({}, nodeAlias);
 const boolean = [...nodeBoolean, ...nodeDevBoolean];

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const { fork } = require('child_process');
 const filewatcher = require('filewatcher');
+const path = require('path');
 const semver = require('semver');
 const { pathToFileURL } = require('url');
 
@@ -20,6 +21,7 @@ module.exports = function (
     debounce,
     dedupe,
     deps,
+    'experimental-loader': wrapLoader,
     graceful_ipc: gracefulIPC,
     ignore,
     interval,
@@ -98,6 +100,14 @@ module.exports = function (
       ? 'loader-legacy.mjs'
       : 'loader.mjs';
     const loader = pathToFileURL(resolveMain(localPath(loaderPath)));
+    if (wrapLoader) {
+      if (wrapLoader.startsWith('.')) {
+        const customLoaderAbsPath = path.resolve(process.cwd(), wrapLoader);
+        loader.searchParams.append('wrap', pathToFileURL(customLoaderAbsPath));
+      } else {
+        loader.searchParams.append('wrap', wrapLoader);
+      }
+    }
     if (semver.satisfies(process.version, '<12.17.0')) {
       args.push('--experimental-modules');
     }

--- a/lib/loader-legacy.mjs
+++ b/lib/loader-legacy.mjs
@@ -4,13 +4,19 @@ import { send } from './ipc.mjs';
 
 const require = createRequire(import.meta.url);
 
+const customLoaderUrl = new URL(import.meta.url).searchParams.get('wrap');
+const customLoader = customLoaderUrl ? await import(customLoaderUrl) : {};
+
+export const resolve = customLoader.resolve;
+
 export async function getFormat(url, context, defaultGetFormat) {
   const getPackageType = require('get-package-type');
   const filePath = fileURLToPath(url);
 
   send({ required: filePath });
+  const customGetFormat = customLoader.load || defaultGetFormat;
   try {
-    return await defaultGetFormat(url, context, defaultGetFormat);
+    return await customGetFormat(url, context, defaultGetFormat);
   } catch (err) {
     if (err.code === 'ERR_UNKNOWN_FILE_EXTENSION') {
       return { format: await getPackageType(filePath) };
@@ -18,3 +24,8 @@ export async function getFormat(url, context, defaultGetFormat) {
     throw err;
   }
 }
+
+export const getSource = customLoader.getSource;
+
+export const transformSource = customLoader.transformSource;
+export const getGlobalPreloadCode = customLoader.getGlobalPreloadCode;

--- a/lib/loader.mjs
+++ b/lib/loader.mjs
@@ -4,13 +4,19 @@ import { send } from './ipc.mjs';
 
 const require = createRequire(import.meta.url);
 
+const customLoaderUrl = new URL(import.meta.url).searchParams.get('wrap');
+const customLoader = customLoaderUrl ? await import(customLoaderUrl) : {};
+
+export const resolve = customLoader.resolve;
+
 export async function load(url, context, defaultLoad) {
   const getPackageType = require('get-package-type');
   const filePath = fileURLToPath(url);
 
   send({ required: filePath });
+  const customLoad = customLoader.load || defaultLoad;
   try {
-    return await defaultLoad(url, context, defaultLoad);
+    return await customLoad(url, context, defaultLoad);
   } catch (err) {
     if (err.code === 'ERR_UNKNOWN_FILE_EXTENSION') {
       return { format: await getPackageType(filePath), source: null };
@@ -18,3 +24,5 @@ export async function load(url, context, defaultLoad) {
     throw err;
   }
 }
+
+export const globalPreload = customLoader.globalPreload;


### PR DESCRIPTION
Closes #242

This adds support for custom ESM loaders options passed via `--experimental-loader` to node-dev. I accomplish this by passing the resolved loader path as a query string argument to node-dev's own ESM loader implementation.

Also, keeping this as a draft until #279 is merged since those changes are more important and this branch builds on top of those commits.