### PR TITLE
Replace resolve with require.resolve

### DIFF
--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -1,8 +1,6 @@
 const { existsSync, readFileSync } = require('fs');
 const { dirname, resolve } = require('path');
 
-const resolveMain = require('./resolve-main');
-
 const defaultConfig = {
   clear: false,
   debounce: 10,
@@ -30,8 +28,7 @@ function read(dir) {
 }
 
 function getConfig(script) {
-  const main = resolveMain(script);
-  const dir = main ? dirname(main) : '.';
+  const dir = resolve(dirname(script));
 
   return Object.assign(
     defaultConfig,

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,16 +1,13 @@
 const { fork } = require('child_process');
 const filewatcher = require('filewatcher');
-const { join } = require('path');
 const semver = require('semver');
 const { pathToFileURL } = require('url');
 
 const { clearFactory } = require('./clear');
 const { configureDeps, configureIgnore } = require('./ignore');
 const ipc = require('./ipc');
-const localPath = require('./local-path');
 const logFactory = require('./log');
 const notifyFactory = require('./notify');
-const resolveMain = require('./resolve-main');
 
 module.exports = function (
   script,
@@ -56,7 +53,7 @@ module.exports = function (
   const isTooDeep = configureDeps(deps);
 
   // Run ./dedupe.js as preload script
-  if (dedupe) process.env.NODE_DEV_PRELOAD = localPath('dedupe');
+  if (dedupe) process.env.NODE_DEV_PRELOAD = require.resolve('./dedupe');
 
   const watcher = filewatcher({ debounce, forcePolling, interval });
   let isPaused = false;
@@ -94,11 +91,11 @@ module.exports = function (
 
     const args = nodeArgs.slice();
 
-    args.push(`--require=${resolveMain(localPath('wrap'))}`);
+    args.push(`--require=${require.resolve('./wrap')}`);
 
     const loaderName = semver.satisfies(process.version, '>=16.12.0') ? 'load' : 'get-format';
 
-    const loaderURL = pathToFileURL(resolveMain(localPath(join('loaders', `${loaderName}.mjs`))));
+    const loaderURL = pathToFileURL(require.resolve(`./loaders/${loaderName}.mjs`));
 
     args.push(`--experimental-loader=${loaderURL.href}`);
 

--- a/lib/local-path.js
+++ b/lib/local-path.js
@@ -1,2 +1,0 @@
-const { join } = require('path');
-module.exports = f => join(__dirname, f);

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,8 +1,6 @@
 const notifier = require('node-notifier');
 
-const localPath = require('./local-path');
-
-const iconLevelPath = level => localPath(`../icons/node_${level}.png`);
+const iconLevelPath = level => require.resolve(`../icons/node_${level}.png`);
 
 // Writes a message to the console and optionally displays a desktop notification.
 module.exports = (notifyEnabled, log) => {

--- a/lib/resolve-main.js
+++ b/lib/resolve-main.js
@@ -1,7 +1,0 @@
-const { sync: resolve } = require('resolve');
-
-module.exports = main => {
-  const basedir = process.cwd();
-  const paths = [basedir];
-  return resolve(main, { basedir, paths });
-};

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -1,12 +1,10 @@
 const { dirname, extname } = require('path');
 const childProcess = require('child_process');
-const { sync: resolve } = require('resolve');
 const { isMainThread } = require('worker_threads');
 
 const { getConfig } = require('./cfg');
 const hook = require('./hook');
 const { relay, send } = require('./ipc');
-const resolveMain = require('./resolve-main');
 const suppressExperimentalWarnings = require('./suppress-experimental-warnings');
 
 // Experimental warnings need to be suppressed in worker threads as well, since
@@ -18,7 +16,7 @@ suppressExperimentalWarnings(process);
 // on the main thread.
 if (!isMainThread) return;
 
-const script = process.argv[1];
+const script = require.resolve(process.argv[1]);
 const { extensions, fork, vm } = getConfig(script);
 
 if (process.env.NODE_DEV_PRELOAD) {
@@ -58,18 +56,16 @@ process.on('uncaughtException', err => {
 hook(vm, required => send({ required }));
 
 // Check if a module is registered for this extension
-const main = resolveMain(script);
-const ext = extname(main).slice(1);
+const ext = extname(script).slice(1);
 const mod = extensions[ext];
-const basedir = dirname(main);
 
 // Support extensions where 'require' returns a function that accepts options
 if (typeof mod === 'object' && mod.name) {
-  const fn = require(resolve(mod.name, { basedir }));
+  const fn = require(require.resolve(mod.name, { paths: [dirname(script)] }));
   if (typeof fn === 'function' && mod.options) {
     // require returned a function, call it with options
     fn(mod.options);
   }
 } else if (typeof mod === 'string') {
-  require(resolve(mod, { basedir }));
+  require(require.resolve(mod, { paths: [dirname(script)] }));
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "get-package-type": "^0.1.0",
     "minimist": "^1.2.6",
     "node-notifier": "^8.0.1",
-    "resolve": "^1.22.0",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
This project currently uses the `resolve` package to resolve paths despite it being a plain Node.js application. Currently, this package doesn't really suffer from any major issues because of this aside from being unable to resolve require hooks that use package `exports` maps rather than `main`, due to this issue https://github.com/browserify/resolve/issues/222#issuecomment-985046830.

Since this library only targets Node, we should be able to drop the resolution helpers for the native thing.