### PR TITLE
[ESM] Fix crash with worker threads (#285)

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -1,6 +1,7 @@
 const { dirname, extname } = require('path');
 const childProcess = require('child_process');
 const { sync: resolve } = require('resolve');
+const { isMainThread } = require('worker_threads');
 
 const { getConfig } = require('./cfg');
 const hook = require('./hook');
@@ -8,14 +9,21 @@ const { relay, send } = require('./ipc');
 const resolveMain = require('./resolve-main');
 const suppressExperimentalWarnings = require('./suppress-experimental-warnings');
 
+// Experimental warnings need to be suppressed in worker threads as well, since
+// their process inherits the Node arguments from the main thread.
+suppressExperimentalWarnings(process);
+
+// When using worker threads, each thread appears to require this file through
+// the shared Node arguments (--require), so filter them out here and only run
+// on the main thread.
+if (!isMainThread) return;
+
 const script = process.argv[1];
 const { extensions, fork, vm } = getConfig(script);
 
 if (process.env.NODE_DEV_PRELOAD) {
   require(process.env.NODE_DEV_PRELOAD);
 }
-
-suppressExperimentalWarnings(process);
 
 // We want to exit on SIGTERM, but defer to existing SIGTERM handlers.
 process.once('SIGTERM', () => process.listenerCount('SIGTERM') || process.exit(0));


### PR DESCRIPTION
When using worker threads, each thread appears to require this file through the shared Node arguments (`--require`, etc.), so filter them out in `wrap.js` and only run on the main thread. The experimental warnings need to be suppressed in worker threads as well, since their process inherits the Node arguments from the main thread.
