### PR TITLE
support registering hook in worker threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ There are a couple of command-line options that can be used to control which fil
 - `--respawn` - Keep watching for changes after the script has exited
 - `--timestamp` - The timestamp format to use for logging restarts
 - `--vm` - Load files using Node's VM
+- `--worker` - Hook into worker_threads.Worker constructor
 
 ## Passing arguments to node
 

--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -21,7 +21,8 @@ const defaultConfig = {
   poll: false,
   respawn: false,
   timestamp: 'HH:MM:ss',
-  vm: true
+  vm: true,
+  worker: true
 };
 
 function read(dir) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,7 +14,7 @@ const nodeBoolean = ['expose_gc', 'preserve-symlinks'];
 const nodeCustom = ['inspect', 'inspect-brk', 'no-warnings'];
 const nodeString = ['require'];
 
-const nodeDevBoolean = ['clear', 'dedupe', 'fork', 'notify', 'poll', 'respawn', 'vm'];
+const nodeDevBoolean = ['clear', 'dedupe', 'fork', 'notify', 'poll', 'respawn', 'vm', 'worker'];
 const nodeDevNumber = ['debounce', 'deps', 'interval'];
 const nodeDevString = ['graceful_ipc', 'ignore', 'timestamp'];
 

--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -1,4 +1,11 @@
+const { once } = require('events');
+const { MessageChannel, Worker } = require('worker_threads');
+
+const logFactory = require('./log');
+
+let nodeDevPort;
 const cmd = 'NODE_DEV';
+const log = logFactory({});
 
 exports.on = (src, prop, cb) => {
   src.on('internalMessage', m => {
@@ -7,11 +14,39 @@ exports.on = (src, prop, cb) => {
 };
 
 exports.relay = src => {
-  src.on('internalMessage', m => {
-    if (process.connected && m.cmd === cmd) process.send(m);
-  });
+  if (src instanceof Worker) {
+    // create a separate message channel for node-dev
+    const { port1, port2 } = new MessageChannel();
+    port1.unref();
+    port1.on('message', exports.send);
+    src.postMessage({ cmd, port: port2 }, [port2]);
+  } else {
+    src.on('internalMessage', m => {
+      if (process.connected && m.cmd === cmd) process.send(m);
+    });
+  }
 };
 
 exports.send = m => {
-  if (process.connected) process.send({ ...m, cmd });
+  if (process.connected) {
+    process.send({ ...m, cmd });
+  } else if (nodeDevPort) {
+    // this has doesn't seem to have a race condition in testing
+    // but just in case, the log statement below should notify of it
+    nodeDevPort.postMessage({ ...m, cmd });
+  } else {
+    log.warn(
+      `node-dev: The module ${m.required} was imported from an orphaned child process or worker thread`
+    );
+  }
+};
+
+exports.receiveMessagePort = async src => {
+  // the first message received by this thread should contain the parent port
+  const [m] = await once(src, 'message');
+  if (m && m.cmd === cmd) {
+    nodeDevPort = m.port;
+  } else {
+    log.warn('node-dev: unexpected message on the parentPort', m);
+  }
 };

--- a/lib/loaders/get-format.mjs
+++ b/lib/loaders/get-format.mjs
@@ -1,6 +1,6 @@
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
-import { send } from './ipc.mjs';
+import { send } from '../ipc.js';
 
 const require = createRequire(import.meta.url);
 

--- a/lib/loaders/ipc.mjs
+++ b/lib/loaders/ipc.mjs
@@ -1,5 +1,0 @@
-const cmd = 'NODE_DEV';
-
-export const send = m => {
-  if (process.connected) process.send({ ...m, cmd });
-};

--- a/lib/loaders/load.mjs
+++ b/lib/loaders/load.mjs
@@ -1,6 +1,6 @@
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
-import { send } from './ipc.mjs';
+import { send } from '../ipc.js';
 
 const require = createRequire(import.meta.url);
 

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -21,7 +21,7 @@ if (workerThreads.isMainThread) {
 }
 
 const script = process.env.NODE_DEV_SCRIPT;
-const { extensions, fork, vm } = getConfig(script);
+const { extensions, fork, worker, vm } = getConfig(script);
 
 if (process.env.NODE_DEV_PRELOAD) {
   require(process.env.NODE_DEV_PRELOAD);
@@ -41,13 +41,15 @@ if (fork) {
   };
 }
 
-const OriginalWorker = workerThreads.Worker;
-workerThreads.Worker = class Worker extends OriginalWorker {
-  constructor(...args) {
-    super(...args);
-    relay(this);
-  }
-};
+if (worker) {
+  const OriginalWorker = workerThreads.Worker;
+  workerThreads.Worker = class Worker extends OriginalWorker {
+    constructor(...args) {
+      super(...args);
+      relay(this);
+    }
+  };
+}
 
 // Error handler that displays a notification and logs the stack to stderr:
 process.on('uncaughtException', err => {

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -15,12 +15,12 @@ if (workerThreads.isMainThread) {
   // When using worker threads, each thread inherits execArgv and re-evaulates
   // --require scripts. Worker threads do not inherit argv, so we copy argv[1]
   // to the environment for those processes to use.
-  process.env.NODE_DEV_SCRIPT = process.argv[1];
+  workerThreads.setEnvironmentData('NODE_DEV_SCRIPT', process.argv[1]);
 } else {
   receiveMessagePort(workerThreads.parentPort);
 }
 
-const script = process.env.NODE_DEV_SCRIPT;
+const script = workerThreads.getEnvironmentData('NODE_DEV_SCRIPT');
 const { extensions, fork, worker, vm } = getConfig(script);
 
 if (process.env.NODE_DEV_PRELOAD) {

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -1,24 +1,26 @@
 const { dirname, extname } = require('path');
 const childProcess = require('child_process');
 const { sync: resolve } = require('resolve');
-const { isMainThread } = require('worker_threads');
+const workerThreads = require('worker_threads');
 
 const { getConfig } = require('./cfg');
 const hook = require('./hook');
-const { relay, send } = require('./ipc');
+const { relay, send, receiveMessagePort } = require('./ipc');
 const resolveMain = require('./resolve-main');
 const suppressExperimentalWarnings = require('./suppress-experimental-warnings');
 
-// Experimental warnings need to be suppressed in worker threads as well, since
-// their process inherits the Node arguments from the main thread.
 suppressExperimentalWarnings(process);
 
-// When using worker threads, each thread appears to require this file through
-// the shared Node arguments (--require), so filter them out here and only run
-// on the main thread.
-if (!isMainThread) return;
+if (workerThreads.isMainThread) {
+  // When using worker threads, each thread inherits execArgv and re-evaulates
+  // --require scripts. Worker threads do not inherit argv, so we copy argv[1]
+  // to the environment for those processes to use.
+  process.env.NODE_DEV_SCRIPT = process.argv[1];
+} else {
+  receiveMessagePort(workerThreads.parentPort);
+}
 
-const script = process.argv[1];
+const script = process.env.NODE_DEV_SCRIPT;
 const { extensions, fork, vm } = getConfig(script);
 
 if (process.env.NODE_DEV_PRELOAD) {
@@ -38,6 +40,14 @@ if (fork) {
     return child;
   };
 }
+
+const OriginalWorker = workerThreads.Worker;
+workerThreads.Worker = class Worker extends OriginalWorker {
+  constructor(...args) {
+    super(...args);
+    relay(this);
+  }
+};
 
 // Error handler that displays a notification and logs the stack to stderr:
 process.on('uncaughtException', err => {

--- a/test/fixture/worker-threads.js
+++ b/test/fixture/worker-threads.js
@@ -27,7 +27,7 @@ if (!isMainThread) {
 
 if (isMainThread) {
   const workers = [...Array(2).keys()].map(n => {
-    console.log('Forking worker', n);
+    console.log('Creating worker thread', n);
     return createWorker(n);
   });
 

--- a/test/fixture/worker-threads.js
+++ b/test/fixture/worker-threads.js
@@ -1,0 +1,41 @@
+const { Worker, isMainThread, parentPort } = require('worker_threads');
+
+const createWorker = i => {
+  const worker = new Worker(__filename);
+
+  worker.on('message', msg => {
+    console.log(`Message from worker ${i}: ${msg}`);
+  });
+
+  worker.on('exit', code => {
+    console.log(`Worker ${i} exited with code: ${code}`);
+  });
+
+  return worker;
+};
+
+if (!isMainThread) {
+  const server = require('./server');
+
+  parentPort.on('close', () => {
+    console.log(`${process.pid} disconnect received, shutting down`);
+    if (server.listening) server.close();
+  });
+
+  parentPort.postMessage('Hello');
+}
+
+if (isMainThread) {
+  const workers = [...Array(2).keys()].map(n => {
+    console.log('Forking worker', n);
+    return createWorker(n);
+  });
+
+  process.once('SIGTERM', () => {
+    console.log('Main thread received SIGTERM');
+
+    Promise.all(workers.map(worker => worker.terminate())).then(() => {
+      console.log('All workers disconnected.');
+    });
+  });
+}

--- a/test/spawn/worker-threads.js
+++ b/test/spawn/worker-threads.js
@@ -1,0 +1,26 @@
+const tap = require('tap');
+
+const { spawn, touchFile } = require('../utils');
+
+tap.test('Restart a multithreaded process', t => {
+  spawn('worker-threads.js', out => {
+    if (out.match(/touch message\.js/m)) {
+      touchFile('message.js');
+      return out2 => {
+        if (out2.match(/Restarting/m)) {
+          return out3 => {
+            if (out3.match(/All workers disconnected/m)) {
+              let shuttingDown = false;
+              return out4 => {
+                if (out4.match(/touch message\.js/) && !shuttingDown) {
+                  shuttingDown = true;
+                  return { exit: t.end.bind(t) };
+                }
+              };
+            }
+          };
+        }
+      };
+    }
+  });
+});


### PR DESCRIPTION
This provides a better implementation for #285 by setting and reading the main script from process.env. This allows modules `require`d from threads to trigger reloads.

I considered some alternative solutions where we monkeypatch into the `Worker` constructor, but ultimately I think an env variable solves this well