### PR TITLE
add --kill timeout option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,7 +15,7 @@ const nodeCustom = ['inspect', 'inspect-brk', 'no-warnings'];
 const nodeString = ['require'];
 
 const nodeDevBoolean = ['clear', 'dedupe', 'fork', 'notify', 'poll', 'respawn', 'vm'];
-const nodeDevNumber = ['debounce', 'deps', 'interval'];
+const nodeDevNumber = ['debounce', 'deps', 'interval', 'kill'];
 const nodeDevString = ['graceful_ipc', 'ignore', 'timestamp'];
 
 const alias = Object.assign({}, nodeAlias);

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,7 @@ module.exports = function (
     graceful_ipc: gracefulIPC,
     ignore,
     interval,
+    kill,
     notify: notifyEnabled,
     poll: forcePolling,
     respawn,
@@ -60,11 +61,21 @@ module.exports = function (
 
   const watcher = filewatcher({ debounce, forcePolling, interval });
   let isPaused = false;
+  let killTimer = 0;
 
   // The child_process
   let child;
 
   watcher.on('change', file => {
+    if (isPaused) return;
+
+    if (typeof kill === 'number') {
+      killTimer = setTimeout(() => {
+        console.log(`Sending SIGKILL after timeout (${kill} sec)`);
+        child.kill('SIGKILL');
+      }, kill * 1000);
+    }
+
     clearOutput();
     notify('Restarting', `${file} has been modified`);
     watcher.removeAll();
@@ -91,7 +102,7 @@ module.exports = function (
    */
   function start() {
     isPaused = false;
-
+    clearTimeout(killTimer);
     const args = nodeArgs.slice();
 
     args.push(`--require=${resolveMain(localPath('wrap'))}`);


### PR DESCRIPTION
I sometimes found a situation when child process failed to react on SIGTERM and kill itself in a timely manner (even if it handled SIGTERM), so it is useful to have ability to force child kill after a timeout.

If you ok with this feature, then some questions to answer:

1) how to name the parameter `--kill` or more explicit `--kill-timeout`?
2) need to add docs.
3) not sure if tests are needed for this.