### PR TITLE
suppress experimental warnings on node 18+

### DIFF
--- a/lib/suppress-experimental-warnings.js
+++ b/lib/suppress-experimental-warnings.js
@@ -1,7 +1,7 @@
 // Source: https://github.com/nodejs/node/issues/30810#issue-533506790
 
 module.exports = p => {
-  const { emitWarning } = p;
+  const { emitWarning, emit } = p;
 
   p.emitWarning = (warning, ...args) => {
     if (args[0] === 'ExperimentalWarning') {
@@ -13,5 +13,24 @@ module.exports = p => {
     }
 
     return emitWarning(warning, ...args);
+  };
+
+  const hasMessage = (obj, message) => {
+    return (
+      obj &&
+      typeof obj === 'object' &&
+      typeof obj.message === 'string' &&
+      obj.message.includes(message)
+    );
+  };
+
+  // prevent experimental warning message spam on node 18+
+  // adapted from https://github.com/yarnpkg/berry/blob/f19f67ef26f004a0b245c81a36158afc45a70504/packages/yarnpkg-pnp/sources/loader/applyPatch.ts#L414-L435
+  p.emit = (name, data, ...args) => {
+    if (name === 'warning' && hasMessage(data, 'Custom ESM Loaders is an experimental feature')) {
+      return false;
+    }
+
+    return emit.call(p, name, data, ...args);
   };
 };

--- a/test/spawn/experimental-warnings.js
+++ b/test/spawn/experimental-warnings.js
@@ -1,0 +1,12 @@
+const tap = require('tap');
+const { spawn } = require('../utils');
+
+tap.test('Should suppress experimental warning spam', t => {
+  spawn('env.js', out => {
+    if (out.match(/ExperimentalWarning/)) return t.fail('Should not log an ExperimentalWarning');
+
+    return {
+      exit: t.end.bind(t)
+    };
+  });
+});


### PR DESCRIPTION
Suppresses this warning that occurs every time you use `node-dev`:

```
(node:1283714) ExperimentalWarning: Custom ESM Loaders is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
```
Also I'm pretty sure the `--no-warnings` option does nothing, since the function that suppresses the warnings is always called. Not sure if that's intentional or not. And the existing unit test for the experimental warning suppression passes even if you omit that flag from the `spawn()` call.

----

I'm not sure which version of Node actually introduced this warning, but I noticed it when upgrading from Node 16 to 18.

fixes #293