### PR TITLE
Implement a global change debounce

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ module.exports = function (
   // Run ./dedupe.js as preload script
   if (dedupe) process.env.NODE_DEV_PRELOAD = localPath('dedupe');
 
-  const watcher = filewatcher({ debounce, forcePolling, interval });
+  const watcher = filewatcher({ forcePolling, interval });
   let isPaused = false;
 
   // The child_process

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ const filewatcher = require('filewatcher');
 const { join } = require('path');
 const semver = require('semver');
 const { pathToFileURL } = require('url');
+const debounceFn = require('debounce');
 
 const { clearFactory } = require('./clear');
 const { configureDeps, configureIgnore } = require('./ignore');
@@ -64,20 +65,23 @@ module.exports = function (
   // The child_process
   let child;
 
-  watcher.on('change', file => {
-    clearOutput();
-    notify('Restarting', `${file} has been modified`);
-    watcher.removeAll();
-    isPaused = true;
-    if (child) {
-      // Child is still running, restart upon exit
-      child.on('exit', start);
-      stop();
-    } else {
-      // Child is already stopped, probably due to a previous error
-      start();
-    }
-  });
+  watcher.on(
+    'change',
+    debounceFn(file => {
+      clearOutput();
+      notify('Restarting', `${file} has been modified`);
+      watcher.removeAll();
+      isPaused = true;
+      if (child) {
+        // Child is still running, restart upon exit
+        child.on('exit', start);
+        stop();
+      } else {
+        // Child is already stopped, probably due to a previous error
+        start();
+      }
+    }, debounce)
+  );
 
   watcher.on('fallback', limit => {
     log.warn('node-dev ran out of file handles after watching %s files.', limit);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "dateformat": "^3.0.3",
+    "debounce": "^1.2.1",
     "dynamic-dedupe": "^0.3.0",
     "filewatcher": "~3.0.0",
     "get-package-type": "^0.1.0",

--- a/test/spawn/debounce-multi-file.js
+++ b/test/spawn/debounce-multi-file.js
@@ -1,0 +1,25 @@
+const tap = require('tap');
+
+const { spawn, touchFile } = require('../utils');
+
+tap.test('should reset debounce timer if a different file changes', t => {
+  spawn('--debounce=1000 --interval=50 server.js', out => {
+    if (out.match(/touch message.js/)) {
+      const ts = Date.now();
+      touchFile('server.js');
+      for (let i = 0; i <= 2000; i += 500) {
+        setTimeout(() => {
+          touchFile('message.js');
+        }, i);
+      }
+      return out2 => {
+        if (out2.match(/Restarting/)) {
+          if (Date.now() - ts < 2500) {
+            t.fail('Debounce logic did not wait 200 ms after the second change.');
+          }
+          return { exit: t.end.bind(t) };
+        }
+      };
+    }
+  });
+});


### PR DESCRIPTION
This changes the debounce timeout to apply globally rather than per-file.  This fixes an issue where if various different files were being changed, the process would restart even though the debounce time had not passed.

Fixes https://github.com/fgnass/node-dev/issues/301